### PR TITLE
adds configuration for protecode and whitesource scanning

### DIFF
--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,0 +1,8 @@
+module-name: infrastructure-manager
+protecode:
+  - europe-docker.pkg.dev/kyma-project/prod/infrastructure-manager:0.0.1
+whitesource:
+  language: golang-mod
+  subprojects: false
+  exclude:
+    - "**/*_test.go"

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: infrastructure-manager
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/infrastructure-manager:0.0.1
+  - europe-docker.pkg.dev/kyma-project/prod/infrastructure-manager:v20230914-5174362c
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- should turn on security scanning in whitesource and protecode 
- ...
- ...

**Related issue(s)**
- #33 
- [example in btp-manager](https://github.com/kyma-project/btp-manager/blob/main/sec-scanners-config.yaml)
- [example in keda-manager](https://github.com/kyma-project/keda-manager/blob/main/sec-scanners-config.yaml )

/area control-plane
/kind feature