### PR TITLE
Update GardenerCluster CRD printed columns

### DIFF
--- a/api/v1/gardenercluster_types.go
+++ b/api/v1/gardenercluster_types.go
@@ -27,6 +27,8 @@ import (
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="STATE",type=string,JSONPath=`.status.state`
 //+kubebuilder:printcolumn:name="RUNTIME-ID",type=string,JSONPath=`.metadata.labels.kyma-project\.io/runtime-id`
+//+kubebuilder:printcolumn:name="SHOOT-NAME",type=string,JSONPath=`.metadata.labels.kyma-project\.io/shoot-name`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // GardenerCluster is the Schema for the clusters API
 type GardenerCluster struct {

--- a/api/v1/gardenercluster_types.go
+++ b/api/v1/gardenercluster_types.go
@@ -25,6 +25,8 @@ import (
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="STATE",type=string,JSONPath=`.status.state`
+//+kubebuilder:printcolumn:name="RUNTIME-ID",type=string,JSONPath=`.metadata.labels.kyma-project\.io/runtime-id`
 
 // GardenerCluster is the Schema for the clusters API
 type GardenerCluster struct {

--- a/config/crd/bases/infrastructuremanager.kyma-project.io_gardenerclusters.yaml
+++ b/config/crd/bases/infrastructuremanager.kyma-project.io_gardenerclusters.yaml
@@ -14,7 +14,14 @@ spec:
     singular: gardenercluster
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: STATE
+      type: string
+    - jsonPath: .metadata.labels.kyma-project\.io/runtime-id
+      name: RUNTIME-ID
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: GardenerCluster is the Schema for the clusters API

--- a/config/crd/bases/infrastructuremanager.kyma-project.io_gardenerclusters.yaml
+++ b/config/crd/bases/infrastructuremanager.kyma-project.io_gardenerclusters.yaml
@@ -21,6 +21,12 @@ spec:
     - jsonPath: .metadata.labels.kyma-project\.io/runtime-id
       name: RUNTIME-ID
       type: string
+    - jsonPath: .metadata.labels.kyma-project\.io/shoot-name
+      name: SHOOT-NAME
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Update GardenerCluster CRD printed columns to show information about CR `state`, `runtime-id` and `shoot-name`.
E.g.

```
$ kubectl get gardenerclusters.infrastructuremanager.kyma-project.io -A
NAMESPACE    NAME         STATE   RUNTIME-ID   SHOOT-NAME   AGE
kcp-system   runtime-id   Ready   runtime-id   shoot-name   2m40s
```

Changes proposed in this pull request:

- `STATE` and `RUNTIME-ID` columns added
