### PR TITLE
Fix invalid condition status for errors in GardenerCluster

### DIFF
--- a/api/v1/gardenercluster_types.go
+++ b/api/v1/gardenercluster_types.go
@@ -123,12 +123,12 @@ func (cluster *GardenerCluster) UpdateConditionForReadyState(conditionType Condi
 	meta.SetStatusCondition(&cluster.Status.Conditions, condition)
 }
 
-func (cluster *GardenerCluster) UpdateConditionForErrorState(conditionType ConditionType, reason ConditionReason, conditionStatus metav1.ConditionStatus, error error) {
+func (cluster *GardenerCluster) UpdateConditionForErrorState(conditionType ConditionType, reason ConditionReason, error error) {
 	cluster.Status.State = ErrorState
 
 	condition := metav1.Condition{
 		Type:               string(conditionType),
-		Status:             conditionStatus,
+		Status:             metav1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(reason),
 		Message:            fmt.Sprintf("%s Error: %s", getMessage(reason), error.Error()),

--- a/internal/controller/gardener_cluster_controller.go
+++ b/internal/controller/gardener_cluster_controller.go
@@ -86,7 +86,7 @@ func (controller *GardenerClusterController) Reconcile(ctx context.Context, req 
 	err := controller.Get(ctx, req.NamespacedName, &cluster)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			err = controller.deleteKubeconfigSecret(req.Name)
+			err = controller.deleteKubeconfigSecret(ctx, req.Name)
 		}
 
 		if err == nil {
@@ -151,13 +151,13 @@ func (controller *GardenerClusterController) persistStatusChange(ctx context.Con
 	return err
 }
 
-func (controller *GardenerClusterController) deleteKubeconfigSecret(clusterCRName string) error {
+func (controller *GardenerClusterController) deleteKubeconfigSecret(ctx context.Context, clusterCRName string) error {
 	selector := client.MatchingLabels(map[string]string{
 		clusterCRNameLabel: clusterCRName,
 	})
 
 	var secretList corev1.SecretList
-	err := controller.Client.List(context.TODO(), &secretList, selector)
+	err := controller.Client.List(ctx, &secretList, selector)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (controller *GardenerClusterController) deleteKubeconfigSecret(clusterCRNam
 		return errors.Errorf("unexpected numer of secrets found for cluster CR `%s`", clusterCRName)
 	}
 
-	return controller.Client.Delete(context.TODO(), &secretList.Items[0])
+	return controller.Client.Delete(ctx, &secretList.Items[0])
 }
 
 func (controller *GardenerClusterController) getSecret(shootName string) (*corev1.Secret, error) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Fix invalid condition status for errors in `GardenerCluster`.

Changes proposed in this pull request:
- fix invalid condition status for errors in GardenerCluster
- fix context for kubeconfig secret deletion
- refactor status change persisting
