### PR TITLE
Kim benchmark improvements

### DIFF
--- a/hack/benchmark/README.md
+++ b/hack/benchmark/README.md
@@ -1,0 +1,24 @@
+# Benchmark
+The 'benchmark.sh' script creates secrets that can be used for benchmarking infrastructure manager.
+
+## Usage
+
+In order to use it, call `./hack/benchmark/benchmark.sh {number_of_secrets_to_generate) {path_to_secret_template)`
+
+Example usage `./hack/benchmark/benchmark.sh 10 ./hack/benchmark/secret.template.json`
+
+Script generates `/tmp/input_{currentdateandtime}.json` input file containing list of runtimeIDs of generated secrets:
+``` json
+[
+  "AB65AB53-7B0A-481C-A472-349B4947D50D",
+  "C212033F-A5F8-416F-BF9C-E735A37D4B0E",
+  "2FFAEDD5-EE90-40F4-955D-DA5493F98263",
+  "C4E7015A-A79A-457D-A5BC-782D8E614568",
+  "70607990-5581-445F-A4D1-2AC9C845DB19",
+  "B9900F40-3A28-4025-A653-353FC91CC603",
+  "BCE7D3F5-8221-48E5-B634-3FB8EC4F2BA8",
+  "32054BD1-5AEA-481A-A9A5-1D8CF7CDF4AD",
+  "AEF09754-E727-4C12-B147-806481D529E5",
+  "F107C364-5144-4F58-ACD0-2111CADF128B"
+]
+```

--- a/hack/benchmark/benchmark.sh
+++ b/hack/benchmark/benchmark.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+_count=$1
+_secret_template_path=$2
+
+function generate_data {
+  jq -nR --arg _count $_count '[range(0;($_count|tonumber)) | input]' < <(while true; do uuidgen ; done)
+}
+
+function create_secrets {
+  cat /dev/stdin | jq -r --argjson t "$(<$_secret_template_path)" '.[] as $id | $t | .metadata.name=$id | .metadata.labels["kyma-project.io/runtime-id"]=$id'
+}
+
+generate_data $1 $2 | tee /tmp/input.json | create_secrets

--- a/hack/benchmark/benchmark.sh
+++ b/hack/benchmark/benchmark.sh
@@ -11,4 +11,7 @@ function create_secrets {
   cat /dev/stdin | jq -r --argjson t "$(<$_secret_template_path)" '.[] as $id | $t | .metadata.name=$id | .metadata.labels["kyma-project.io/runtime-id"]=$id'
 }
 
-generate_data $1 $2 | tee /tmp/input.json | create_secrets
+datetime_postfix=$(date -u +%Y-%m-%dT%H:%M:%S) 
+input_filename="/tmp/input_"$datetime_postfix".json"
+echo $input_filename 
+generate_data $1 $2 | tee $input_filename | create_secrets

--- a/hack/benchmark/benchmark.sh
+++ b/hack/benchmark/benchmark.sh
@@ -4,7 +4,7 @@ _count=$1
 _secret_template_path=$2
 
 function generate_data {
-  jq -nR --arg _count $_count '[range(0;($_count|tonumber)) | input]' < <(while true; do uuidgen ; done)
+  jq -nR --arg _count $_count '[range(0;($_count|tonumber)) | input]' < <(while true; do uuidgen | awk '{print tolower($0)}' ; done)
 }
 
 function create_secrets {
@@ -13,5 +13,4 @@ function create_secrets {
 
 datetime_postfix=$(date -u +%Y-%m-%dT%H:%M:%S) 
 input_filename="/tmp/input_"$datetime_postfix".json"
-echo $input_filename 
 generate_data $1 $2 | tee $input_filename | create_secrets

--- a/hack/benchmark/secret.template.json
+++ b/hack/benchmark/secret.template.json
@@ -1,0 +1,16 @@
+{
+    "apiVersion": "v1",
+    "data": {
+        "config": "dGhpcyBpcyBmb3IgdGVzdHMgb25seQ=="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "labels": {
+            "kyma-project.io/runtime-id": "01a5af79-b073-48a1-906d-26c15933b12a",
+            "kyma-project.io/shoot-name": "benchmark-invalid"
+        },
+        "name": "kubeconfig-01a5af79-b073-48a1-906d-26c15933b12a",
+        "namespace": "kcp-system"
+    },
+    "type": "Opaque"
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- put file name is based on date and time so it will be possible to easily revisit or possibly undo multiple benchmark runs
- fixes an issue where the output of the script couldn't be piped to `kubectl apply` because runtimeIDs were not lowercase
- adds documentation on how to use benchmark.sh

**Related issue(s)**
- Improves https://github.com/kyma-project/infrastructure-manager/pull/71 
