### PR TITLE
renames control-manager to intrastructure-manager

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -28,7 +28,7 @@ resources:
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
+# If you want your infrastructure-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 - manager_gardener_secret_patch.yaml

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system
 spec:
   template:

--- a/config/default/manager_gardener_secret_patch.yaml
+++ b/config/default/manager_gardener_secret_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system
 spec:
   template:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: custom-infrastructure-manager
-  newTag: 0.0.1
+  newName: custom-im
+  newTag: 2.2.7

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: infrastructure-manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
@@ -14,12 +14,12 @@ metadata:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: infrastructure-manager
     app.kubernetes.io/name: deployment
-    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/instance: infrastructure-manager
     app.kubernetes.io/component: manager
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
@@ -27,14 +27,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: infrastructure-manager
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: infrastructure-manager
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
@@ -98,5 +98,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: infrastructure-manager
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: infrastructure-manager
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
-    app.kubernetes.io/component: manager
+    app.kubernetes.io/component: infrastructure-manager.kyma-project.io
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
@@ -20,7 +20,7 @@ metadata:
     control-plane: infrastructure-manager
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: infrastructure-manager
-    app.kubernetes.io/component: manager
+    app.kubernetes.io/component: infrastructure-manager.kyma-project.io
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
@@ -28,6 +28,7 @@ spec:
   selector:
     matchLabels:
       control-plane: infrastructure-manager
+      app.kubernetes.io/component: infrastructure-manager.kyma-project.io
   replicas: 1
   template:
     metadata:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,14 +4,14 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: infrastructure-manager
     app.kubernetes.io/name: servicemonitor
-    app.kubernetes.io/instance: controller-manager-metrics-monitor
+    app.kubernetes.io/instance: infrastructure-manager-metrics-monitor
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-monitor
+  name: infrastructure-manager-metrics-monitor
   namespace: system
 spec:
   endpoints:
@@ -23,4 +23,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: infrastructure-manager

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -15,5 +15,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,14 +2,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: infrastructure-manager
     app.kubernetes.io/name: service
-    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/instance: infrastructure-manager-metrics-service
     app.kubernetes.io/component: kube-rbac-proxy
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: infrastructure-manager-metrics-service
   namespace: system
 spec:
   ports:
@@ -18,4 +18,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: infrastructure-manager

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -15,5 +15,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -15,5 +15,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -3,10 +3,10 @@ kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/name: serviceaccount
-    app.kubernetes.io/instance: controller-manager-sa
+    app.kubernetes.io/instance: infrastructure-manager-sa
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager
+  name: infrastructure-manager
   namespace: system


### PR DESCRIPTION
**Description**

`kubectl -n kcp-system get service infrastructure-manager -o yaml | yq .spec.selector
control-plane: controller-manager` is pulling 2 other unrelated components' pods. 

Changes proposed in this pull request:

- renaming from `controller-manager` to `infrastructure-manager`
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
