### PR TITLE
renames infrastructure manager roles and rolebindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ help: ## Display this help.
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) rbac:roleName=infrastructure-manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,7 @@ spec:
         kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: infrastructure-manager
+        app.kubernetes.io/component: infrastructure-manager.kyma-project.io
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -3,12 +3,12 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: rolebinding
-    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/instance: infrastructure-manager-le-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
-  name: leader-election-rolebinding
+  name: infrastructure-manager-le-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: infrastructure-manager-role
 rules:
 - apiGroups:
   - ""

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -3,16 +3,16 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: clusterrolebinding
-    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/instance: infrastructure-manager-rolebinding
     app.kubernetes.io/component: rbac
     app.kubernetes.io/created-by: infrastructure-manager
     app.kubernetes.io/part-of: infrastructure-manager
     app.kubernetes.io/managed-by: kustomize
-  name: manager-rolebinding
+  name: infrastructure-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: infrastructure-manager-role
 subjects:
 - kind: ServiceAccount
   name: infrastructure-manager


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
renaming of:
- leader-election-role
- leader-election-rolebinding
- manager-role
- manager-rolebinding

**Related issue(s)**
#93 