### PR TITLE
managed-by secret label is set to lifecycle-manager

### DIFF
--- a/internal/controller/gardener_cluster_controller.go
+++ b/internal/controller/gardener_cluster_controller.go
@@ -384,7 +384,7 @@ func (controller *GardenerClusterController) newSecret(cluster imv1.GardenerClus
 	for key, val := range cluster.Labels {
 		labels[key] = val
 	}
-	labels["operator.kyma-project.io/managed-by"] = "infrastructure-manager"
+	labels["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	labels[clusterCRNameLabel] = cluster.Name
 
 	return corev1.Secret{

--- a/internal/controller/gardener_cluster_controller_test.go
+++ b/internal/controller/gardener_cluster_controller_test.go
@@ -239,7 +239,7 @@ type TestSecret struct {
 
 func fixSecretLabels(kymaName, shootName string) map[string]string {
 	labels := fixGardenerClusterLabels(kymaName, shootName)
-	labels["operator.kyma-project.io/managed-by"] = "infrastructure-manager"
+	labels["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	labels["operator.kyma-project.io/cluster-name"] = kymaName
 	return labels
 }


### PR DESCRIPTION
**Description**
`lifecycle-manager` currently relies on label `operator.kyma-project.io/managed-by=lifecycle-manager`. 


Changes proposed in this pull request:

- This PR sets that label **temporarily** to required.
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
