### PR TITLE
configures golang/govulncheck-action

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.5'
+          go-version: '1.21'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21.5'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -15,5 +15,5 @@ jobs:
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: 1.21.4
+        go-version-input: 1.21.5
         go-package: ./...

--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -1,0 +1,19 @@
+name: Run vuln check
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: vulncheck
+      uses: golang/govulncheck-action@v1
+      with:
+        go-version-input: 1.21.4
+        go-package: ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM golang:1.21.5 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/infrastructure-manager
 
-go 1.21.5
+go 1.21
 
 require (
 	github.com/gardener/gardener v1.85.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/infrastructure-manager
 
-go 1.21
+go 1.21.5
 
 require (
 	github.com/gardener/gardener v1.85.0


### PR DESCRIPTION
- configures golang/govulncheck-action in this repository
- bumps golang to 1.21.5
- linter uses 1.25.1 version of golang