### PR TITLE
changes managed-by label from lifecycle-manager to infrastructure-manager

### DIFF
--- a/internal/controller/gardener_cluster_controller.go
+++ b/internal/controller/gardener_cluster_controller.go
@@ -393,7 +393,7 @@ func (controller *GardenerClusterController) newSecret(cluster imv1.GardenerClus
 	for key, val := range cluster.Labels {
 		labels[key] = val
 	}
-	labels["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
+	labels["operator.kyma-project.io/managed-by"] = "infrastructure-manager"
 	labels[clusterCRNameLabel] = cluster.Name
 
 	return corev1.Secret{

--- a/internal/controller/gardener_cluster_controller_test.go
+++ b/internal/controller/gardener_cluster_controller_test.go
@@ -239,7 +239,7 @@ type TestSecret struct {
 
 func fixSecretLabels(kymaName, shootName string) map[string]string {
 	labels := fixGardenerClusterLabels(kymaName, shootName)
-	labels["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
+	labels["operator.kyma-project.io/managed-by"] = "infrastructure-manager"
 	labels["operator.kyma-project.io/cluster-name"] = kymaName
 	return labels
 }


### PR DESCRIPTION
**Description**

Secrets are now managed by infrastructure-manager, the corresponding label should reflect that

Changes proposed in this pull request:

- changes `managed-by` label from `lifecycle-manager` to `infrastructure-manager`.
- ...
- ...

**Related issue(s)**
- internal backlog item no. 4826 
- https://github.com/kyma-project/lifecycle-manager/pull/1160
