### PR TITLE
chore: Adjust dependabot PR titles to use prefix 'chore'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "chore: "
+      prefix: "chore"


### PR DESCRIPTION
**Description**

As follow-up of PR #283 , we also adjust the PR title for dependabot.

**Related issue(s)**
- #backlog/5699
