### PR TITLE
[WiP] feat: Saving Runtime CR to Persistent Volume

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -172,6 +172,7 @@ func main() {
 	cfg := fsm.RCCfg{
 		Finalizer:       infrastructuremanagerv1.Finalizer,
 		ShootNamesapace: gardenerNamespace,
+		SaveToPV:        persistShoot,
 		ConverterConfig: converterConfig,
 	}
 

--- a/internal/controller/runtime/fsm/runtime_fsm.go
+++ b/internal/controller/runtime/fsm/runtime_fsm.go
@@ -30,6 +30,7 @@ type writerGetter = func(filePath string) (io.Writer, error)
 type RCCfg struct {
 	Finalizer       string
 	PVCPath         string
+	SaveToPV        bool
 	ShootNamesapace string
 	shoot.ConverterConfig
 }

--- a/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_create_shoot.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"context"
+	runtime_comparer "github.com/kyma-project/infrastructure-manager/internal/testing/runtime-comparer"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -9,6 +10,22 @@ import (
 
 func sFnCreateShoot(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl.Result, error) {
 	m.log.Info("Create shoot")
+
+	if m.SaveToPV {
+		err := runtime_comparer.WriteToPV(s.instance, m.PVCPath)
+		if err != nil {
+			m.log.Error(err, "Failed to write Runtime CR to Persistent Volume")
+
+			s.instance.UpdateStatePending(
+				imv1.ConditionTypeRuntimeProvisioned,
+				imv1.ConditionReasonProcessingErr,
+				"False",
+				"Failed to write Runtime CR to Persistent Volume",
+			)
+			return updateStatusAndRequeueAfter(gardenerRequeueDuration)
+		}
+	}
+
 	newShoot, err := convertShoot(&s.instance, m.ConverterConfig)
 	if err != nil {
 		m.log.Error(err, "Failed to convert Runtime instance to shoot object")

--- a/internal/testing/runtime-comparer/pv_writer.go
+++ b/internal/testing/runtime-comparer/pv_writer.go
@@ -1,0 +1,37 @@
+package runtime_comparer
+
+import (
+	"fmt"
+	v1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"os"
+	"sigs.k8s.io/yaml"
+)
+
+func WriteToPV(instance v1.Runtime, path string) error {
+	fileName := path + "/" + instance.Name + ".yaml"
+	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+
+	// Remove managed fields from the object
+	instance.ManagedFields = nil
+	b, err := yaml.Marshal(instance)
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("failed to marshal Runtime object: %w", err, b)
+	}
+
+	_, err = file.Write(b)
+	if err != nil {
+		file.Close()
+		return fmt.Errorf("failed to write to file: %w", err)
+	}
+
+	if err := file.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
To have a comparison app which will compare the Provisioner and KIM provisioning input request we need to store RuntimeCR in PersistentVolume.


Changes proposed in this pull request:

- logic which saves the KIM Runtime CR object to mounted Volume

**Related issue(s)**
#185 