### PR TITLE
sets confirmation.gardener.cloud/force-deletion annotation to true 

### DIFF
--- a/internal/gardener/shoot/extender/annotations.go
+++ b/internal/gardener/shoot/extender/annotations.go
@@ -11,10 +11,11 @@ import (
 //- support.gardener.cloud/eu-access-for-cluster-nodes
 
 const (
-	ShootRuntimeIDAnnotation          = "infrastructuremanager.kyma-project.io/runtime-id"
-	ShootLicenceTypeAnnotation        = "infrastructuremanager.kyma-project.io/licence-type"
-	RuntimeIDLabel                    = "kyma-project.io/runtime-id"
-	ShootRestrictedEUAccessAnnotation = "support.gardener.cloud/eu-access-for-cluster-nodes"
+	RuntimeIDLabel                            = "kyma-project.io/runtime-id"
+	ShootRuntimeIDAnnotation                  = "infrastructuremanager.kyma-project.io/runtime-id"
+	ShootLicenceTypeAnnotation                = "infrastructuremanager.kyma-project.io/licence-type"
+	GardenerShootRestrictedEUAccessAnnotation = "support.gardener.cloud/eu-access-for-cluster-nodes"
+	GardenerForceDeletionAnnotation           = "confirmation.gardener.cloud/force-deletion"
 )
 
 func ExtendWithAnnotations(runtime imv1.Runtime, shoot *gardener.Shoot) error {
@@ -33,8 +34,10 @@ func getAnnotations(runtime imv1.Runtime) map[string]string {
 	}
 
 	if isEuAccess(runtime.Spec.Shoot.PlatformRegion) {
-		annotations[ShootRestrictedEUAccessAnnotation] = "true"
+		annotations[GardenerShootRestrictedEUAccessAnnotation] = "true"
 	}
+
+	annotations[GardenerForceDeletionAnnotation] = "true"
 
 	return annotations
 }

--- a/internal/gardener/shoot/extender/annotations_test.go
+++ b/internal/gardener/shoot/extender/annotations_test.go
@@ -29,7 +29,9 @@ func TestAnnotationsExtender(t *testing.T) {
 				},
 			},
 			expectedAnnotations: map[string]string{
-				"infrastructuremanager.kyma-project.io/runtime-id": "runtime-id"},
+				"infrastructuremanager.kyma-project.io/runtime-id": "runtime-id",
+				"confirmation.gardener.cloud/force-deletion":       "true",
+			},
 		},
 		{
 			name: "Create licence type annotation",
@@ -49,7 +51,8 @@ func TestAnnotationsExtender(t *testing.T) {
 			},
 			expectedAnnotations: map[string]string{
 				"infrastructuremanager.kyma-project.io/runtime-id":   "runtime-id",
-				"infrastructuremanager.kyma-project.io/licence-type": "licence"},
+				"infrastructuremanager.kyma-project.io/licence-type": "licence",
+				"confirmation.gardener.cloud/force-deletion":         "true"},
 		},
 		{
 			name: "Create restricted EU access annotation for cf-eu11 region",
@@ -69,7 +72,8 @@ func TestAnnotationsExtender(t *testing.T) {
 			},
 			expectedAnnotations: map[string]string{
 				"infrastructuremanager.kyma-project.io/runtime-id":   "runtime-id",
-				"support.gardener.cloud/eu-access-for-cluster-nodes": "true"},
+				"support.gardener.cloud/eu-access-for-cluster-nodes": "true",
+				"confirmation.gardener.cloud/force-deletion":         "true"},
 		},
 		{
 			name: "Create restricted EU access annotation for cf-ch20 region",
@@ -89,7 +93,8 @@ func TestAnnotationsExtender(t *testing.T) {
 			},
 			expectedAnnotations: map[string]string{
 				"infrastructuremanager.kyma-project.io/runtime-id":   "runtime-id",
-				"support.gardener.cloud/eu-access-for-cluster-nodes": "true"},
+				"support.gardener.cloud/eu-access-for-cluster-nodes": "true",
+				"confirmation.gardener.cloud/force-deletion":         "true"},
 		},
 	} {
 		// given


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- sets `confirmation.gardener.cloud/force-deletion annotation` annotation to true for new clusters
- Tiny refactoring
  - aggregating consts so ones used by gardener are close 
  - name clearly shows which annotations are used by gardener

**Related issue(s)**
#103 
