### PR TITLE
Maintenance extender

### DIFF
--- a/config/manager/converter_config.yaml
+++ b/config/manager/converter_config.yaml
@@ -7,8 +7,8 @@ data:
     {
       "kubernetes": {
         "defaultVersion": "1.29",
-        "kubernetesVersion": true,
-        "machineImageVersion": false
+        "enableKubernetesVersionAutoUpdate": true,
+        "enableMachineImageVersionAutoUpdate": false
       },
       "dns": {
         "secretName": "aws-route53-secret-dev",

--- a/config/manager/converter_config.yaml
+++ b/config/manager/converter_config.yaml
@@ -6,7 +6,9 @@ data:
   converter_config_aws.json: |
     {
       "kubernetes": {
-        "defaultVersion": "1.29"
+        "defaultVersion": "1.29",
+        "kubernetesVersion": true,
+        "machineImageVersion": false
       },
       "dns": {
         "secretName": "aws-route53-secret-dev",

--- a/converter_config.json
+++ b/converter_config.json
@@ -1,8 +1,8 @@
 {
   "kubernetes": {
     "defaultVersion": "1.29",
-    "kubernetesVersion": true,
-    "machineImageVersion": false
+    "enableKubernetesVersionAutoUpdate": true,
+    "enableMachineImageVersionAutoUpdate": false
   },
   "dns": {
     "secretName": "aws-route53-secret-dev",

--- a/converter_config.json
+++ b/converter_config.json
@@ -1,6 +1,8 @@
 {
   "kubernetes": {
-    "defaultVersion": "1.29"
+    "defaultVersion": "1.29",
+    "kubernetesVersion": true,
+    "machineImageVersion": false
   },
   "dns": {
     "secretName": "aws-route53-secret-dev",

--- a/internal/controller/runtime/fsm/runtime_fsm_delete_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_delete_shoot.go
@@ -2,9 +2,9 @@ package fsm
 
 import (
 	"context"
-	"k8s.io/utils/ptr"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/internal/controller/runtime/fsm/runtime_fsm_delete_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_delete_shoot.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"context"
+	"k8s.io/utils/ptr"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,7 +19,7 @@ func sFnDeleteShoot(ctx context.Context, m *fsm, s *systemState) (stateFn, *ctrl
 
 		err := m.ShootClient.Patch(ctx, s.shoot, client.Apply, &client.PatchOptions{
 			FieldManager: "kim",
-			Force:        ptrTo(true),
+			Force:        ptr.To(true),
 		})
 
 		if err != nil {

--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -2,12 +2,12 @@ package fsm
 
 import (
 	"context"
-	"k8s.io/utils/ptr"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot"
 	gardener_shoot "github.com/kyma-project/infrastructure-manager/internal/gardener/shoot"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"context"
+	"k8s.io/utils/ptr"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
@@ -24,7 +25,7 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 
 	err = m.ShootClient.Patch(ctx, &updatedShoot, client.Apply, &client.PatchOptions{
 		FieldManager: "kim",
-		Force:        ptrTo(true),
+		Force:        ptr.To(true),
 	})
 
 	if err != nil {
@@ -83,8 +84,4 @@ func updateStatePendingWithErrorAndStop(instance *imv1.Runtime,
 	c imv1.RuntimeConditionType, r imv1.RuntimeConditionReason, msg string) (stateFn, *ctrl.Result, error) {
 	instance.UpdateStatePending(c, r, "False", msg)
 	return updateStatusAndStop()
-}
-
-func ptrTo[T any](v T) *T {
-	return &v
 }

--- a/internal/controller/runtime/suite_test.go
+++ b/internal/controller/runtime/suite_test.go
@@ -18,7 +18,6 @@ package runtime
 
 import (
 	"context"
-	"k8s.io/utils/ptr"
 	"path/filepath"
 	"testing"
 
@@ -34,6 +33,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"

--- a/internal/controller/runtime/suite_test.go
+++ b/internal/controller/runtime/suite_test.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"context"
+	"k8s.io/utils/ptr"
 	"path/filepath"
 	"testing"
 
@@ -179,7 +180,7 @@ func fixShootsSequenceForProvisioning(shoot *gardener_api.Shoot) []*gardener_api
 	dnsShoot := initialisedShoot.DeepCopy()
 
 	dnsShoot.Spec.DNS = &gardener_api.DNS{
-		Domain: ptrTo("test.domain"),
+		Domain: ptr.To("test.domain"),
 	}
 
 	pendingShoot := dnsShoot.DeepCopy()
@@ -208,7 +209,7 @@ func fixShootsSequenceForUpdate(shoot *gardener_api.Shoot) []*gardener_api.Shoot
 	pendingShoot := shoot.DeepCopy()
 
 	pendingShoot.Spec.DNS = &gardener_api.DNS{
-		Domain: ptrTo("test.domain"),
+		Domain: ptr.To("test.domain"),
 	}
 
 	pendingShoot.Status = gardener_api.ShootStatus{
@@ -251,8 +252,4 @@ func fixConverterConfigForTests() gardener_shoot.ConverterConfig {
 			ProjectName: "kyma-dev", //nolint:godox TODO: should be parametrised
 		},
 	}
-}
-
-func ptrTo[T any](v T) *T {
-	return &v
 }

--- a/internal/gardener/shoot/converter.go
+++ b/internal/gardener/shoot/converter.go
@@ -33,9 +33,9 @@ type DNSConfig struct {
 }
 
 type KubernetesConfig struct {
-	DefaultVersion      string `json:"defaultVersion" validate:"required"`
-	KubernetesVersion   bool   `json:"kubernetesVersion"`
-	MachineImageVersion bool   `json:"machineImageVersion"`
+	DefaultVersion                      string `json:"defaultVersion" validate:"required"`
+	EnableKubernetesVersionAutoUpdate   bool   `json:"enableKubernetesVersionAutoUpdate"`
+	EnableMachineImageVersionAutoUpdate bool   `json:"enableMachineImageVersionVersionAutoUpdate"`
 }
 
 type ReaderGetter = func() (io.Reader, error)
@@ -77,7 +77,7 @@ func NewConverter(config ConverterConfig) Converter {
 		extender.ExtendWithCertConfig,
 		extender.ExtendWithExposureClassName,
 		extender.ExtendWithTolerations,
-		extender.NewMaintenanceExtender(config.Kubernetes.KubernetesVersion, config.Kubernetes.MachineImageVersion),
+		extender.NewMaintenanceExtender(config.Kubernetes.EnableKubernetesVersionAutoUpdate, config.Kubernetes.EnableMachineImageVersionAutoUpdate),
 	}
 
 	return Converter{

--- a/internal/gardener/shoot/converter.go
+++ b/internal/gardener/shoot/converter.go
@@ -33,7 +33,9 @@ type DNSConfig struct {
 }
 
 type KubernetesConfig struct {
-	DefaultVersion string `json:"defaultVersion" validate:"required"`
+	DefaultVersion      string `json:"defaultVersion" validate:"required"`
+	KubernetesVersion   bool   `json:"kubernetesVersion"`
+	MachineImageVersion bool   `json:"machineImageVersion"`
 }
 
 type ReaderGetter = func() (io.Reader, error)
@@ -74,6 +76,7 @@ func NewConverter(config ConverterConfig) Converter {
 		extender.ExtendWithNetworkFilter,
 		extender.ExtendWithExposureClassName,
 		extender.ExtendWithTolerations,
+		extender.NewMaintenanceExtender(config.Kubernetes.KubernetesVersion, config.Kubernetes.MachineImageVersion),
 	}
 
 	return Converter{

--- a/internal/gardener/shoot/converter_test.go
+++ b/internal/gardener/shoot/converter_test.go
@@ -40,7 +40,9 @@ func TestConverter(t *testing.T) {
 func fixConverterConfig() ConverterConfig {
 	return ConverterConfig{
 		Kubernetes: KubernetesConfig{
-			DefaultVersion: "1.29", //nolint:godox TODO: set on deployment level
+			DefaultVersion:      "1.29",
+			KubernetesVersion:   true,
+			MachineImageVersion: false,
 		},
 		DNS: DNSConfig{
 			SecretName:   "dns-secret",
@@ -134,7 +136,9 @@ func Test_ConverterConfig_Load_Err(t *testing.T) {
 
 var testReader io.Reader = strings.NewReader(`{
   "kubernetes": {
-    "defaultVersion": "0.1.2.3"
+    "defaultVersion": "0.1.2.3",
+    "kubernetesVersion": true,
+    "machineImageVersion": false
   },
   "dns": {
     "secretName": "test-secret-name",
@@ -165,7 +169,9 @@ func Test_ConverterConfig_Load_OK(t *testing.T) {
 
 	expected := ConverterConfig{
 		Kubernetes: KubernetesConfig{
-			DefaultVersion: "0.1.2.3",
+			DefaultVersion:      "0.1.2.3",
+			KubernetesVersion:   true,
+			MachineImageVersion: false,
 		},
 		DNS: DNSConfig{
 			SecretName:   "test-secret-name",

--- a/internal/gardener/shoot/converter_test.go
+++ b/internal/gardener/shoot/converter_test.go
@@ -40,9 +40,9 @@ func TestConverter(t *testing.T) {
 func fixConverterConfig() ConverterConfig {
 	return ConverterConfig{
 		Kubernetes: KubernetesConfig{
-			DefaultVersion:      "1.29",
-			KubernetesVersion:   true,
-			MachineImageVersion: false,
+			DefaultVersion:                      "1.29",
+			EnableKubernetesVersionAutoUpdate:   true,
+			EnableMachineImageVersionAutoUpdate: false,
 		},
 		DNS: DNSConfig{
 			SecretName:   "dns-secret",
@@ -137,8 +137,8 @@ func Test_ConverterConfig_Load_Err(t *testing.T) {
 var testReader io.Reader = strings.NewReader(`{
   "kubernetes": {
     "defaultVersion": "0.1.2.3",
-    "kubernetesVersion": true,
-    "machineImageVersion": false
+    "enableKubernetesVersionAutoUpdate": true,
+    "enableMachineImageVersionAutoUpdate": false
   },
   "dns": {
     "secretName": "test-secret-name",
@@ -169,9 +169,9 @@ func Test_ConverterConfig_Load_OK(t *testing.T) {
 
 	expected := ConverterConfig{
 		Kubernetes: KubernetesConfig{
-			DefaultVersion:      "0.1.2.3",
-			KubernetesVersion:   true,
-			MachineImageVersion: false,
+			DefaultVersion:                      "0.1.2.3",
+			EnableKubernetesVersionAutoUpdate:   true,
+			EnableMachineImageVersionAutoUpdate: false,
 		},
 		DNS: DNSConfig{
 			SecretName:   "test-secret-name",

--- a/internal/gardener/shoot/extender/exposure_classname_extender.go
+++ b/internal/gardener/shoot/extender/exposure_classname_extender.go
@@ -4,12 +4,13 @@ import (
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot/hyperscaler"
+	"k8s.io/utils/ptr"
 )
 
 // ExposureClassName is required only for OpenStack
 func ExtendWithExposureClassName(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 	if runtime.Spec.Shoot.Provider.Type == hyperscaler.TypeOpenStack {
-		shoot.Spec.ExposureClassName = ToPtr("converged-cloud-internet")
+		shoot.Spec.ExposureClassName = ptr.To("converged-cloud-internet")
 	}
 
 	return nil

--- a/internal/gardener/shoot/extender/kubernetes_version_test.go
+++ b/internal/gardener/shoot/extender/kubernetes_version_test.go
@@ -1,12 +1,12 @@
 package extender
 
 import (
-	"k8s.io/utils/ptr"
 	"testing"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 )
 
 func TestKubernetesVersionExtender(t *testing.T) {

--- a/internal/gardener/shoot/extender/kubernetes_version_test.go
+++ b/internal/gardener/shoot/extender/kubernetes_version_test.go
@@ -1,6 +1,7 @@
 package extender
 
 import (
+	"k8s.io/utils/ptr"
 	"testing"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
@@ -30,7 +31,7 @@ func TestKubernetesVersionExtender(t *testing.T) {
 			Spec: imv1.RuntimeSpec{
 				Shoot: imv1.RuntimeShoot{
 					Kubernetes: imv1.Kubernetes{
-						Version: ToPtr("1.88"),
+						Version: ptr.To("1.88"),
 					},
 				},
 			},

--- a/internal/gardener/shoot/extender/maintenance.go
+++ b/internal/gardener/shoot/extender/maintenance.go
@@ -6,12 +6,12 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func NewMaintenanceExtender(kubernetesVersion, machineImageVersion bool) func(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
+func NewMaintenanceExtender(enableKubernetesVersionAutoUpdate, enableMachineImageVersionAutoUpdate bool) func(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
 	return func(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
 		shoot.Spec.Maintenance = &gardener.Maintenance{
 			AutoUpdate: &gardener.MaintenanceAutoUpdate{
-				KubernetesVersion:   kubernetesVersion,
-				MachineImageVersion: ptr.To(machineImageVersion),
+				KubernetesVersion:   enableKubernetesVersionAutoUpdate,
+				MachineImageVersion: ptr.To(enableMachineImageVersionAutoUpdate),
 			},
 		}
 

--- a/internal/gardener/shoot/extender/maintenance.go
+++ b/internal/gardener/shoot/extender/maintenance.go
@@ -1,0 +1,20 @@
+package extender
+
+import (
+	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"k8s.io/utils/ptr"
+)
+
+func NewMaintenanceExtender(kubernetesVersion, machineImageVersion bool) func(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
+	return func(runtime imv1.Runtime, shoot *gardener.Shoot) error {
+		shoot.Spec.Maintenance = &gardener.Maintenance{
+			AutoUpdate: &gardener.MaintenanceAutoUpdate{
+				KubernetesVersion:   kubernetesVersion,
+				MachineImageVersion: ptr.To(machineImageVersion),
+			},
+		}
+
+		return nil
+	}
+}

--- a/internal/gardener/shoot/extender/maintenance.go
+++ b/internal/gardener/shoot/extender/maintenance.go
@@ -7,7 +7,7 @@ import (
 )
 
 func NewMaintenanceExtender(kubernetesVersion, machineImageVersion bool) func(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
-	return func(runtime imv1.Runtime, shoot *gardener.Shoot) error {
+	return func(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
 		shoot.Spec.Maintenance = &gardener.Maintenance{
 			AutoUpdate: &gardener.MaintenanceAutoUpdate{
 				KubernetesVersion:   kubernetesVersion,

--- a/internal/gardener/shoot/extender/maintenance_test.go
+++ b/internal/gardener/shoot/extender/maintenance_test.go
@@ -10,19 +10,19 @@ import (
 
 func TestMaintenanceExtender(t *testing.T) {
 	for _, testCase := range []struct {
-		name                string
-		kubernetesVersion   bool
-		machineImageVersion bool
+		name                                string
+		enableKubernetesVersionAutoUpdate   bool
+		enableMachineImageVersionAutoUpdate bool
 	}{
 		{
-			name:                "Enable auto-update for only kubernetesVersion",
-			kubernetesVersion:   true,
-			machineImageVersion: false,
+			name:                                "Enable auto-update for only KubernetesVersion",
+			enableKubernetesVersionAutoUpdate:   true,
+			enableMachineImageVersionAutoUpdate: false,
 		},
 		{
-			name:                "Enable auto-update for only machineImageVersion",
-			kubernetesVersion:   false,
-			machineImageVersion: true,
+			name:                                "Enable auto-update for only MachineImageVersion",
+			enableKubernetesVersionAutoUpdate:   false,
+			enableMachineImageVersionAutoUpdate: true,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
@@ -40,13 +40,13 @@ func TestMaintenanceExtender(t *testing.T) {
 			}
 
 			// when
-			extender := NewMaintenanceExtender(testCase.kubernetesVersion, testCase.machineImageVersion)
+			extender := NewMaintenanceExtender(testCase.enableKubernetesVersionAutoUpdate, testCase.enableMachineImageVersionAutoUpdate)
 			err := extender(runtimeShoot, &shoot)
 
 			// then
 			assert.NoError(t, err)
-			assert.Equal(t, testCase.kubernetesVersion, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion)
-			assert.Equal(t, testCase.machineImageVersion, *shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion)
+			assert.Equal(t, testCase.enableKubernetesVersionAutoUpdate, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion)
+			assert.Equal(t, testCase.enableMachineImageVersionAutoUpdate, *shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion)
 		})
 	}
 }

--- a/internal/gardener/shoot/extender/maintenance_test.go
+++ b/internal/gardener/shoot/extender/maintenance_test.go
@@ -1,10 +1,10 @@
 package extender
 
 import (
-	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"testing"
 
+	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/gardener/shoot/extender/maintenance_test.go
+++ b/internal/gardener/shoot/extender/maintenance_test.go
@@ -1,0 +1,52 @@
+package extender
+
+import (
+	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaintenanceExtender(t *testing.T) {
+	for _, testCase := range []struct {
+		name                string
+		kubernetesVersion   bool
+		machineImageVersion bool
+	}{
+		{
+			name:                "Enable auto-update for only kubernetesVersion",
+			kubernetesVersion:   true,
+			machineImageVersion: false,
+		},
+		{
+			name:                "Enable auto-update for only machineImageVersion",
+			kubernetesVersion:   false,
+			machineImageVersion: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// given
+			shoot := fixEmptyGardenerShoot("test", "dev")
+			shoot.Spec.Maintenance = &gardener.Maintenance{
+				AutoUpdate: &gardener.MaintenanceAutoUpdate{},
+			}
+			runtimeShoot := imv1.Runtime{
+				Spec: imv1.RuntimeSpec{
+					Shoot: imv1.RuntimeShoot{
+						Name: "test",
+					},
+				},
+			}
+
+			// when
+			extender := NewMaintenanceExtender(testCase.kubernetesVersion, testCase.machineImageVersion)
+			err := extender(runtimeShoot, &shoot)
+
+			// then
+			assert.NoError(t, err)
+			assert.Equal(t, testCase.kubernetesVersion, shoot.Spec.Maintenance.AutoUpdate.KubernetesVersion)
+			assert.Equal(t, testCase.machineImageVersion, *shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion)
+		})
+	}
+}

--- a/internal/gardener/shoot/extender/network_filter.go
+++ b/internal/gardener/shoot/extender/network_filter.go
@@ -3,6 +3,7 @@ package extender
 import (
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"k8s.io/utils/ptr"
 )
 
 const NetworkFilterType = "shoot-networking-filter"
@@ -10,14 +11,10 @@ const NetworkFilterType = "shoot-networking-filter"
 func ExtendWithNetworkFilter(runtime imv1.Runtime, shoot *gardener.Shoot) error { //nolint:revive
 	networkingFilter := gardener.Extension{
 		Type:     NetworkFilterType,
-		Disabled: ToPtr(false),
+		Disabled: ptr.To(false),
 	}
 
 	shoot.Spec.Extensions = append(shoot.Spec.Extensions, networkingFilter)
 
 	return nil
-}
-
-func ToPtr[T any](v T) *T {
-	return &v
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adds maintenance extender which allows configuration of auto-updates via `kubernetesVersion` and `machineImageVersion` 
- switches to k8s util `ptr.To`

**Related issue(s)**
#230 
