### PR TITLE
Fixes for making shoot comparison easier

### DIFF
--- a/hack/shoot-comparator/pkg/shoot/matcher.go
+++ b/hack/shoot-comparator/pkg/shoot/matcher.go
@@ -90,9 +90,120 @@ func (m *Matcher) Match(actual interface{}) (success bool, err error) {
 			path:          "metadata/annotations",
 		},
 		{
-			GomegaMatcher: gomega.Equal(eShoot.Spec),
-			expected:      aShoot.Spec,
-			path:          "spec",
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Addons),
+			expected:      aShoot.Spec.Addons,
+			path:          "spec/Addons",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.CloudProfileName),
+			expected:      aShoot.Spec.CloudProfileName,
+			path:          "spec/CloudProfileName",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.DNS),
+			expected:      aShoot.Spec.DNS,
+			path:          "spec/DNS",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Extensions),
+			expected:      aShoot.Spec.Extensions,
+			path:          "spec/Extensions",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Hibernation),
+			expected:      aShoot.Spec.Hibernation,
+			path:          "spec/Hibernation",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Kubernetes),
+			expected:      aShoot.Spec.Kubernetes,
+			path:          "spec/Kubernetes",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Networking),
+			expected:      aShoot.Spec.Networking,
+			path:          "spec/Networking",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Maintenance),
+			expected:      aShoot.Spec.Maintenance,
+			path:          "spec/Maintenance",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Monitoring),
+			expected:      aShoot.Spec.Monitoring,
+			path:          "spec/Monitoring",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Provider),
+			expected:      aShoot.Spec.Provider,
+			path:          "spec/Provider",
+		},
+
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Purpose),
+			expected:      aShoot.Spec.Purpose,
+			path:          "spec/Purpose",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Region),
+			expected:      aShoot.Spec.Region,
+			path:          "spec/Region",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.SecretBindingName),
+			expected:      aShoot.Spec.SecretBindingName,
+			path:          "spec/SecretBindingName",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.SeedName),
+			expected:      aShoot.Spec.SeedName,
+			path:          "spec/SeedName",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.SeedSelector),
+			expected:      aShoot.Spec.SeedSelector,
+			path:          "spec/SeedSelector",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Resources),
+			expected:      aShoot.Spec.Resources,
+			path:          "spec/Resources",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.Tolerations),
+			expected:      aShoot.Spec.Tolerations,
+			path:          "spec/Tolerations",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.ExposureClassName),
+			expected:      aShoot.Spec.ExposureClassName,
+			path:          "spec/ExposureClassName",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.SystemComponents),
+			expected:      aShoot.Spec.SystemComponents,
+			path:          "spec/SystemComponents",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.ControlPlane),
+			expected:      aShoot.Spec.ControlPlane,
+			path:          "spec/ControlPlane",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.SchedulerName),
+			expected:      aShoot.Spec.SchedulerName,
+			path:          "spec/SchedulerName",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.CloudProfile),
+			expected:      aShoot.Spec.CloudProfile,
+			path:          "spec/CloudProfile",
+		},
+		{
+			GomegaMatcher: gomega.Equal(eShoot.Spec.CredentialsBindingName),
+			expected:      aShoot.Spec.CredentialsBindingName,
+			path:          "spec/CredentialsBindingName",
 		},
 	} {
 		ok, err := matcher.Match(matcher.expected)

--- a/hack/shoot-comparator/pkg/shoot/matcher.go
+++ b/hack/shoot-comparator/pkg/shoot/matcher.go
@@ -64,6 +64,8 @@ func (m *Matcher) Match(actual interface{}) (success bool, err error) {
 		return false, err
 	}
 
+	// Note: we define separate matchers for each field to make input more readable
+	// Annotations are not matched as they are not relevant for the comparison ; both KIM, and Provisioner have different set of annotations
 	for _, matcher := range []matcher{
 		{
 			GomegaMatcher: gomega.Equal(eShoot.TypeMeta),
@@ -83,11 +85,6 @@ func (m *Matcher) Match(actual interface{}) (success bool, err error) {
 			GomegaMatcher: gomega.Equal(eShoot.Labels),
 			expected:      aShoot.Labels,
 			path:          "metadata/labels",
-		},
-		{
-			GomegaMatcher: gomega.Equal(eShoot.Annotations),
-			expected:      aShoot.Annotations,
-			path:          "metadata/annotations",
 		},
 		{
 			GomegaMatcher: gomega.Equal(eShoot.Spec.Addons),

--- a/hack/shoot-comparator/pkg/shoot/matcher_test.go
+++ b/hack/shoot-comparator/pkg/shoot/matcher_test.go
@@ -26,12 +26,6 @@ func withLabels(labels map[string]string) deepCpOpts {
 	}
 }
 
-func withAnnotations(annotations map[string]string) deepCpOpts {
-	return func(s *v1beta1.Shoot) {
-		s.Annotations = annotations
-	}
-}
-
 func withShootSpec(spec v1beta1.ShootSpec) deepCpOpts {
 	return func(s *v1beta1.Shoot) {
 		s.Spec = spec
@@ -101,12 +95,6 @@ var _ = Describe(":: shoot matcher :: ", func() {
 			"should detect difference in labels",
 			deepCp(empty, withLabels(map[string]string{"test": "me"})),
 			deepCp(empty, withLabels(map[string]string{})),
-			false,
-		),
-		Entry(
-			"should detect difference in annotations",
-			deepCp(empty, withAnnotations(map[string]string{"test": "me"})),
-			deepCp(empty, withAnnotations(map[string]string{"test": "it"})),
 			false,
 		),
 		Entry(

--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -49,11 +49,6 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 		"Shoot is pending",
 	)
 
-	shouldDumpShootSpec := m.PVCPath != ""
-	if shouldDumpShootSpec {
-		return switchState(sFnDumpShootSpec)
-	}
-
 	return updateStatusAndRequeueAfter(gardenerRequeueDuration)
 }
 
@@ -63,13 +58,13 @@ func convertShoot(instance *imv1.Runtime, cfg shoot.ConverterConfig) (gardener.S
 	}
 
 	converter := gardener_shoot.NewConverter(cfg)
-	shoot, err := converter.ToShoot(*instance)
+	newShoot, err := converter.ToShoot(*instance)
 
 	if err == nil {
-		setObjectFields(&shoot)
+		setObjectFields(&newShoot)
 	}
 
-	return shoot, err
+	return newShoot, err
 }
 
 // workaround

--- a/internal/controller/runtime/fsm/testing/shoot.go
+++ b/internal/controller/runtime/fsm/testing/shoot.go
@@ -18,6 +18,20 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-instance",
 			Namespace: "default",
+			Labels: map[string]string{
+				"kyma-project.io/instance-id":         "instance-id",
+				"kyma-project.io/runtime-id":          "runtime-id",
+				"kyma-project.io/shoot-name":          "shoot-name",
+				"kyma-project.io/region":              "region",
+				"operator.kyma-project.io/kyma-name":  "kyma-name",
+				"kyma-project.io/broker-plan-id":      "broker-plan-id",
+				"kyma-project.io/broker-plan-name":    "broker-plan-name",
+				"kyma-project.io/global-account-id":   "global-account-id",
+				"kyma-project.io/subaccount-id":       "subaccount-id",
+				"operator.kyma-project.io/managed-by": "managed-by",
+				"operator.kyma-project.io/internal":   "false",
+				"kyma-project.io/platform-region":     "platform-region",
+			},
 		},
 		Spec: v1.RuntimeSpec{
 			Shoot: v1.RuntimeShoot{Name: "test-shoot"},

--- a/internal/controller/runtime/fsm/utilz_for_test.go
+++ b/internal/controller/runtime/fsm/utilz_for_test.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"fmt"
+	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot"
 
 	. "github.com/onsi/gomega" //nolint:revive
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,6 +32,13 @@ var (
 	withStorageWriter = func(testWriterGetter writerGetter) fakeFSMOpt {
 		return func(fsm *fsm) error {
 			fsm.writerProvider = testWriterGetter
+			return nil
+		}
+	}
+
+	withConverterConfig = func(config shoot.ConverterConfig) fakeFSMOpt {
+		return func(fsm *fsm) error {
+			fsm.ConverterConfig = config
 			return nil
 		}
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Matchers perform more granular comparison to make results easier to read
- Annotations are not compared as both KIM and Provisioner create different annotations set
- Shoot spec stored on the persistent volume does not contain fields that are not relevant for comparison 
- Shoot spec not stored on upgrade to align with the Provisioner

**Related issue(s)**
#185 
