### PR TITLE
Removes bearerTokenFile and tlsConfig from prometheus service monitor

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -18,9 +18,6 @@ spec:
     - path: /metrics
       port: metrics
       scheme: http
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
   selector:
     matchLabels:
       app.kubernetes.io/name: metrics


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Modification requested by security audit
- Removes `bearerTokenFile` and `tlsConfig` from prometheus service monitor
- This is used only for local development and not very often  
- Verification would be time consuming and I did not test this change (minimal impact) 
