### PR TITLE
oidc extension added only if controlled-by-provisioner value is disabled

### DIFF
--- a/internal/gardener/shoot/extender/dns_test.go
+++ b/internal/gardener/shoot/extender/dns_test.go
@@ -58,6 +58,9 @@ func fixEmptyGardenerShoot(name, namespace string) gardener.Shoot {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels: map[string]string{
+				"kyma-project.io/controlled-by-provisioner": "false",
+			},
 		},
 		Spec: gardener.ShootSpec{},
 	}

--- a/internal/gardener/shoot/extender/dns_test.go
+++ b/internal/gardener/shoot/extender/dns_test.go
@@ -58,9 +58,7 @@ func fixEmptyGardenerShoot(name, namespace string) gardener.Shoot {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels: map[string]string{
-				"kyma-project.io/controlled-by-provisioner": "false",
-			},
+			Labels:    map[string]string{},
 		},
 		Spec: gardener.ShootSpec{},
 	}

--- a/internal/gardener/shoot/extender/oidc.go
+++ b/internal/gardener/shoot/extender/oidc.go
@@ -22,11 +22,11 @@ func ExtendWithOIDC(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 }
 
 func CanEnableExtension(shoot *gardener.Shoot) bool {
-	controlledByProvisionerLabelValue := shoot.Labels[imv1.LabelControlledByProvisioner]
-	canEnable := false
+	canEnable := true
+	createdByMigrator := shoot.Labels["operator.kyma-project.io/created-by-migrator"]
 
-	if controlledByProvisionerLabelValue == "false" {
-		canEnable = true
+	if createdByMigrator == "true" {
+		canEnable = false
 	}
 
 	return canEnable

--- a/internal/gardener/shoot/extender/oidc.go
+++ b/internal/gardener/shoot/extender/oidc.go
@@ -13,7 +13,7 @@ const (
 func ExtendWithOIDC(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 	oidcConfig := runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig
 
-	if CanEnableExtension(shoot) {
+	if CanEnableExtension(runtime) {
 		setOIDCExtension(shoot)
 	}
 	setKubeAPIServerOIDCConfig(shoot, oidcConfig)
@@ -21,9 +21,9 @@ func ExtendWithOIDC(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 	return nil
 }
 
-func CanEnableExtension(shoot *gardener.Shoot) bool {
+func CanEnableExtension(runtime imv1.Runtime) bool {
 	canEnable := true
-	createdByMigrator := shoot.Labels["operator.kyma-project.io/created-by-migrator"]
+	createdByMigrator := runtime.Labels["operator.kyma-project.io/created-by-migrator"]
 
 	if createdByMigrator == "true" {
 		canEnable = false

--- a/internal/gardener/shoot/extender/oidc.go
+++ b/internal/gardener/shoot/extender/oidc.go
@@ -13,10 +13,23 @@ const (
 func ExtendWithOIDC(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 	oidcConfig := runtime.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig
 
-	setOIDCExtension(shoot)
+	if CanEnableExtension(shoot) {
+		setOIDCExtension(shoot)
+	}
 	setKubeAPIServerOIDCConfig(shoot, oidcConfig)
 
 	return nil
+}
+
+func CanEnableExtension(shoot *gardener.Shoot) bool {
+	controlledByProvisionerLabelValue := shoot.Labels[imv1.LabelControlledByProvisioner]
+	canEnable := false
+
+	if controlledByProvisionerLabelValue == "false" {
+		canEnable = true
+	}
+
+	return canEnable
 }
 
 func setOIDCExtension(shoot *gardener.Shoot) {

--- a/internal/gardener/shoot/extender/oidc_test.go
+++ b/internal/gardener/shoot/extender/oidc_test.go
@@ -1,6 +1,7 @@
 package extender
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -40,8 +41,12 @@ func TestOidcExtender(t *testing.T) {
 			usernameClaim := "sub"
 
 			shoot := fixEmptyGardenerShoot("test", "kcp-system")
-			shoot.Labels[MigratorLabel] = testCase.migratorLabel[MigratorLabel]
 			runtimeShoot := imv1.Runtime{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						MigratorLabel: testCase.migratorLabel[MigratorLabel],
+					},
+				},
 				Spec: imv1.RuntimeSpec{
 					Shoot: imv1.RuntimeShoot{
 						Kubernetes: imv1.Kubernetes{

--- a/internal/gardener/shoot/extender/oidc_test.go
+++ b/internal/gardener/shoot/extender/oidc_test.go
@@ -71,6 +71,8 @@ func TestOidcExtender(t *testing.T) {
 			if testCase.expectedOidcExtensionEnabled {
 				assert.Equal(t, testCase.expectedOidcExtensionEnabled, !*shoot.Spec.Extensions[0].Disabled)
 				assert.Equal(t, "shoot-oidc-service", shoot.Spec.Extensions[0].Type)
+			} else {
+				assert.Equal(t, 0, len(shoot.Spec.Extensions))
 			}
 		})
 	}

--- a/internal/gardener/shoot/extender/oidc_test.go
+++ b/internal/gardener/shoot/extender/oidc_test.go
@@ -10,42 +10,68 @@ import (
 )
 
 func TestOidcExtender(t *testing.T) {
-	t.Run("Create kubernetes config", func(t *testing.T) {
-		// given
-		clientID := "client-id"
-		groupsClaim := "groups"
-		issuerURL := "https://my.cool.tokens.com"
-		usernameClaim := "sub"
+	const MigratorLabel = "operator.kyma-project.io/created-by-migrator"
+	for _, testCase := range []struct {
+		name                         string
+		migratorLabel                map[string]string
+		expectedOidcExtensionEnabled bool
+	}{
+		{
+			name:                         "label created-by-migrator=true should not configure OIDC",
+			migratorLabel:                map[string]string{MigratorLabel: "true"},
+			expectedOidcExtensionEnabled: false,
+		},
+		{
+			name:                         "label created-by-migrator=false should configure OIDC",
+			migratorLabel:                map[string]string{MigratorLabel: "false"},
+			expectedOidcExtensionEnabled: true,
+		},
+		{
+			name:                         "label created-by-migrator unset should configure OIDC",
+			migratorLabel:                nil,
+			expectedOidcExtensionEnabled: true,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			// given
+			clientID := "client-id"
+			groupsClaim := "groups"
+			issuerURL := "https://my.cool.tokens.com"
+			usernameClaim := "sub"
 
-		shoot := fixEmptyGardenerShoot("test", "kcp-system")
-		runtimeShoot := imv1.Runtime{
-			Spec: imv1.RuntimeSpec{
-				Shoot: imv1.RuntimeShoot{
-					Kubernetes: imv1.Kubernetes{
-						KubeAPIServer: imv1.APIServer{
-							OidcConfig: gardener.OIDCConfig{
-								ClientID:    &clientID,
-								GroupsClaim: &groupsClaim,
-								IssuerURL:   &issuerURL,
-								SigningAlgs: []string{
-									"RS256",
+			shoot := fixEmptyGardenerShoot("test", "kcp-system")
+			shoot.Labels[MigratorLabel] = testCase.migratorLabel[MigratorLabel]
+			runtimeShoot := imv1.Runtime{
+				Spec: imv1.RuntimeSpec{
+					Shoot: imv1.RuntimeShoot{
+						Kubernetes: imv1.Kubernetes{
+							KubeAPIServer: imv1.APIServer{
+								OidcConfig: gardener.OIDCConfig{
+									ClientID:    &clientID,
+									GroupsClaim: &groupsClaim,
+									IssuerURL:   &issuerURL,
+									SigningAlgs: []string{
+										"RS256",
+									},
+									UsernameClaim: &usernameClaim,
 								},
-								UsernameClaim: &usernameClaim,
 							},
 						},
 					},
 				},
-			},
-		}
+			}
 
-		// when
-		err := ExtendWithOIDC(runtimeShoot, &shoot)
+			// when
+			err := ExtendWithOIDC(runtimeShoot, &shoot)
 
-		// then
-		require.NoError(t, err)
+			// then
+			require.NoError(t, err)
 
-		assert.Equal(t, runtimeShoot.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig, *shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig)
-		assert.Equal(t, false, *shoot.Spec.Extensions[0].Disabled)
-		assert.Equal(t, "shoot-oidc-service", shoot.Spec.Extensions[0].Type)
-	})
+			assert.Equal(t, runtimeShoot.Spec.Shoot.Kubernetes.KubeAPIServer.OidcConfig, *shoot.Spec.Kubernetes.KubeAPIServer.OIDCConfig)
+			if testCase.expectedOidcExtensionEnabled {
+				assert.Equal(t, testCase.expectedOidcExtensionEnabled, !*shoot.Spec.Extensions[0].Disabled)
+				assert.Equal(t, "shoot-oidc-service", shoot.Spec.Extensions[0].Type)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**Description**
Adjusts feature parity of OIDC extension enablement between Provisioner and KIM. As for @tobiscr request:
> The Provisioner is enabling it only for new runtimes. In KIM, it looks like we enable it always - also for updates.
> Would KIM be able to detect if the RUntime was already created, or does it not know whether a Runtime is new or already exists?


Changes proposed in this pull request:

- extension applied only if `"operator.kyma-project.io/created-by-migrator": "true"` is not set
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/infrastructure-manager/issues/381
