### PR TITLE
Configuration of GH workflows to use go version 1.23.0

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22.4'
+          go-version: '1.23.0'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4.0.0

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,7 +25,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.58.2
+          version: 'latest'
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,7 +25,7 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: 'latest'
+          version: v1.61.0
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,7 +20,7 @@ jobs:
           go-version: '1.23.0'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.0.0
+        uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 #v6.1.0
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -20,7 +20,7 @@ jobs:
           go-version: '1.23.0'
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4.0.0
+        uses: golangci/golangci-lint-action@v6.0.0
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -35,7 +35,7 @@ jobs:
           # Note: By default, the `.golangci.yml` file should be at the root of the repository.
           # The location of the configuration file can be changed by using `--config=`
           # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0 
-          args: --timeout=5m --skip-files=.*_test\.go --skip-dirs=internal/controller/runtime/fsm/testing
+          args: --timeout=10m --skip-files=.*_test\.go --skip-dirs=internal/controller/runtime/fsm/testing --verbose
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -49,7 +49,7 @@ jobs:
     - name: Set up go environment
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.4
+        go-version: 1.23.0
 ############################################################################################
     - name: Run unit tests
       run: make test

--- a/.github/workflows/run-vuln-check.yaml
+++ b/.github/workflows/run-vuln-check.yaml
@@ -15,5 +15,5 @@ jobs:
     - name: vulncheck
       uses: golang/govulncheck-action@v1
       with:
-        go-version-input: 1.22.5
+        go-version-input: 1.23.0
         go-package: ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/infrastructure-manager
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/gardener/gardener v1.100.0

--- a/hack/shoot-comparator/Dockerfile
+++ b/hack/shoot-comparator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5-alpine AS build
+FROM golang:1.23.0-alpine3.20 as build
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/hack/shoot-comparator/go.mod
+++ b/hack/shoot-comparator/go.mod
@@ -1,12 +1,11 @@
 module github.com/kyma-project/infrastructure-manager/tools/shoot-comparator
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/gardener/gardener v1.98.0
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
**Description**
1. Update of golang version to `1.23.0` in GH actions 
2. Updated build image for shoot-comparator app to `golang:1.23.0-alpine3.20`

Updated GH actions:

- golangci-lint (change version format to SHA tag, to ensure safety, use latest version of golangci-lint, and increase timeout to 10 m)
- run-tests
- vulncheck

