### PR TITLE
Fixes to migrator that will remove unimportant differences

### DIFF
--- a/hack/runtime-migrator/main.go
+++ b/hack/runtime-migrator/main.go
@@ -206,7 +206,7 @@ func createRuntime(ctx context.Context, shoot v1beta1.Shoot, cfg migrator.Config
 				},
 				Provider: v1.Provider{
 					Type:    shoot.Spec.Provider.Type,
-					Workers: getWorkersConfig(shoot.Spec.Provider.Workers),
+					Workers: adjustWorkersConfig(shoot.Spec.Provider.Workers),
 				},
 				Networking: v1.Networking{
 					Type:     shoot.Spec.Networking.Type,
@@ -245,7 +245,7 @@ func createRuntime(ctx context.Context, shoot v1beta1.Shoot, cfg migrator.Config
 
 // The goal of this function is to make the migrator output equal to the shoot created by the converter
 // As a result we can automatically verify the correctness of the migrator output
-func getWorkersConfig(workers []v1beta1.Worker) []v1beta1.Worker {
+func adjustWorkersConfig(workers []v1beta1.Worker) []v1beta1.Worker {
 	// We need to set the following fields to nil, as they are not set by the KIM converter
 	for i := 0; i < len(workers); i++ {
 		workers[i].Machine.Architecture = nil

--- a/hack/runtime-migrator/main.go
+++ b/hack/runtime-migrator/main.go
@@ -206,7 +206,7 @@ func createRuntime(ctx context.Context, shoot v1beta1.Shoot, cfg migrator.Config
 				},
 				Provider: v1.Provider{
 					Type:    shoot.Spec.Provider.Type,
-					Workers: shoot.Spec.Provider.Workers,
+					Workers: getWorkersConfig(shoot.Spec.Provider.Workers),
 				},
 				Networking: v1.Networking{
 					Type:     shoot.Spec.Networking.Type,
@@ -214,7 +214,6 @@ func createRuntime(ctx context.Context, shoot v1beta1.Shoot, cfg migrator.Config
 					Nodes:    *shoot.Spec.Networking.Nodes,
 					Services: *shoot.Spec.Networking.Services,
 				},
-				ControlPlane: getControlPlane(shoot),
 			},
 			Security: v1.Security{
 				Administrators: subjects,
@@ -235,7 +234,26 @@ func createRuntime(ctx context.Context, shoot v1beta1.Shoot, cfg migrator.Config
 			Conditions: nil, // deliberately left nil by our migrator to show that controller has not picked it yet
 		},
 	}
+
+	controlPlane := getControlPlane(shoot)
+	if controlPlane != nil {
+		runtime.Spec.Shoot.ControlPlane = controlPlane
+	}
+
 	return runtime, nil
+}
+
+// The goal of this function is to make the migrator output equal to the shoot created by the converter
+// As a result we can automatically verify the correctness of the migrator output
+func getWorkersConfig(workers []v1beta1.Worker) []v1beta1.Worker {
+	// We need to set the following fields to nil, as they are not set by the KIM converter
+	for i := 0; i < len(workers); i++ {
+		workers[i].Machine.Architecture = nil
+		workers[i].SystemComponents = nil
+		workers[i].CRI = nil
+	}
+
+	return workers
 }
 
 func getOidcConfig(shoot v1beta1.Shoot) v1beta1.OIDCConfig {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Migrator no longer sets `worker.machine.architecture`, `worker.systemcomponents`, `worker.cri`

**Related issue(s)**
#342 