### PR TITLE
Handle the Kubernetes conflict error in KIM Audit Log

### DIFF
--- a/internal/auditlogging/auditlogging.go
+++ b/internal/auditlogging/auditlogging.go
@@ -147,9 +147,14 @@ func ApplyAuditLogConfig(shoot *gardener.Shoot, auditConfigFromFile map[string]m
 	}
 
 	changedExt, err := configureExtension(shoot, tenant)
+
+	if err != nil {
+		return false, err
+	}
+
 	changedSec := configureSecret(shoot, tenant)
 
-	return changedExt || changedSec, err
+	return changedExt || changedSec, nil
 }
 
 func configureExtension(shoot *gardener.Shoot, config AuditLogData) (changed bool, err error) {

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog.go
@@ -3,11 +3,10 @@ package fsm
 import (
 	"context"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/auditlogging"
 	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog.go
@@ -2,6 +2,7 @@ package fsm
 
 import (
 	"context"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog_test.go
@@ -2,9 +2,10 @@ package fsm
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kyma-project/infrastructure-manager/internal/auditlogging"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"testing"
 
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1 "github.com/kyma-project/infrastructure-manager/api/v1"

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_auditlog_test.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kyma-project/infrastructure-manager/internal/auditlogging"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"github.com/kyma-project/infrastructure-manager/internal/auditlogging"
 	"github.com/kyma-project/infrastructure-manager/internal/auditlogging/mocks"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/internal/controller/runtime/fsm/runtime_fsm_waiting_for_shoot_reconcile.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_waiting_for_shoot_reconcile.go
@@ -49,7 +49,7 @@ func sFnWaitForShootReconcile(_ context.Context, m *fsm, s *systemState) (stateF
 			imv1.ConditionTypeRuntimeProvisioned,
 			imv1.ConditionReasonAuditLogConfigured,
 			"Runtime processing completed successfully",
-			sFnConfigureAuditLog)
+			sFnApplyClusterRoleBindings)
 	}
 
 	m.log.Info("Update did not processed, exiting with no retry")

--- a/internal/controller/runtime/fsm/runtime_fsm_waiting_for_shoot_reconcile.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_waiting_for_shoot_reconcile.go
@@ -47,7 +47,7 @@ func sFnWaitForShootReconcile(_ context.Context, m *fsm, s *systemState) (stateF
 		return ensureStatusConditionIsSetAndContinue(
 			&s.instance,
 			imv1.ConditionTypeRuntimeProvisioned,
-			imv1.ConditionReasonAuditLogConfigured,
+			imv1.ConditionReasonConfigurationCompleted,
 			"Runtime processing completed successfully",
 			sFnApplyClusterRoleBindings)
 	}

--- a/internal/controller/runtime/runtime_controller_test.go
+++ b/internal/controller/runtime/runtime_controller_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Runtime Controller", func() {
 					return false
 				}
 
-				if !runtime.IsConditionSet(imv1.ConditionTypeRuntimeProvisioned, imv1.ConditionReasonAuditLogConfigured) {
+				if !runtime.IsConditionSet(imv1.ConditionTypeRuntimeProvisioned, imv1.ConditionReasonConfigurationCompleted) {
 					return false
 				}
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- proceed to immediately requeue if was Kubernetes conflict error during Gardener Shoot object update
