### PR TITLE
Remove worker zones sorting

### DIFF
--- a/internal/gardener/shoot/extender/provider.go
+++ b/internal/gardener/shoot/extender/provider.go
@@ -1,6 +1,8 @@
 package extender
 
 import (
+	"slices"
+
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot/hyperscaler"
@@ -10,7 +12,6 @@ import (
 	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot/hyperscaler/openstack"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"slices"
 )
 
 func NewProviderExtender(enableIMDSv2 bool, defaultMachineImageName, defaultMachineImageVersion string) func(runtime imv1.Runtime, shoot *gardener.Shoot) error {

--- a/internal/gardener/shoot/extender/provider.go
+++ b/internal/gardener/shoot/extender/provider.go
@@ -1,8 +1,6 @@
 package extender
 
 import (
-	"slices"
-
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
 	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot/hyperscaler"
@@ -12,6 +10,7 @@ import (
 	"github.com/kyma-project/infrastructure-manager/internal/gardener/shoot/hyperscaler/openstack"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"slices"
 )
 
 func NewProviderExtender(enableIMDSv2 bool, defaultMachineImageName, defaultMachineImageVersion string) func(runtime imv1.Runtime, shoot *gardener.Shoot) error {
@@ -90,11 +89,14 @@ func getZones(workers []gardener.Worker) []string {
 	var zones []string
 
 	for _, worker := range workers {
-		zones = append(zones, worker.Zones...)
+		for _, zone := range worker.Zones {
+			if !slices.Contains(zones, zone) {
+				zones = append(zones, zone)
+			}
+		}
 	}
-	slices.Sort(zones)
 
-	return slices.Compact(zones)
+	return zones
 }
 
 func setWorkerConfig(provider *gardener.Provider, providerType string, enableIMDSv2 bool) error {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
In order to not changing the existing zones assignment during reconciliation of the old runtimes we need to remove the zones sorting.

Changes proposed in this pull request:

- remove sorting the workers zones

