### PR TITLE
removes docs and configs for removed runtime-reconciler-enabled flag

### DIFF
--- a/config/default/manager_gardener_secret_patch.yaml
+++ b/config/default/manager_gardener_secret_patch.yaml
@@ -23,7 +23,6 @@ spec:
             - --kubeconfig-expiration-time=24h
             - --minimal-rotation-time=0.6
             - --gardener-request-timeout=60s
-            - --runtime-reconciler-enabled=false
           volumeMounts:
             - name: gardener-kubeconfig
               mountPath: /gardener/credentials

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,8 @@ You can configure the Infrastructure Manager deployment with the following argum
 3. `minimal-rotation-time` - the ratio determines what is the minimal time that needs to pass to rotate the certificate
 4. `kubeconfig-expiration-time` - maximum time after which kubeconfig is rotated. The rotation happens between (`minimal-rotation-time` * `kubeconfig-expiration-time`) and `kubeconfig-expiration-time`.
 4. `gardener-request-timeout` - specifies the timeout for requests to Gardener. Default value is `60s`.
-5. `runtime-reconciler-enabled` - feature flag responsible for enabling the runtime reconciler. Default value is `true`.
-6. `shoot-spec-dump-enabled` - feature flag responsible for enabling the shoot spec dump. Default value is `false`.
-7. `audit-log-mandatory` - feature flag responsible for enabling the Audit Log strict config. Default value is `true`.
+5. `shoot-spec-dump-enabled` - feature flag responsible for enabling the shoot spec dump. Default value is `false`.
+6. `audit-log-mandatory` - feature flag responsible for enabling the Audit Log strict config. Default value is `true`.
 
 
 See [manager_gardener_secret_patch.yaml](../config/default/manager_gardener_secret_patch.yaml) for default values.


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- removes docs and configs for already deleted `runtime-reconciler-enabled` flag
- ...
- ...

**Related issue(s)**
- [Related commit](https://github.com/kyma-project/infrastructure-manager/commit/f3390d3e79c3986ba7a5c1a5edaccd4536bd2a87)
- internal/management-plane-config/5793 
- internal/management-plane-charts/2136
