### PR TITLE
Add new extender to enforce configuration of shoot seed within the same region as the shoot

### DIFF
--- a/internal/controller/runtime/suite_test.go
+++ b/internal/controller/runtime/suite_test.go
@@ -39,7 +39,6 @@ import (
 	v12 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	//nolint:revive
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"

--- a/pkg/gardener/shoot/converter.go
+++ b/pkg/gardener/shoot/converter.go
@@ -17,7 +17,7 @@ func baseExtenders(cfg config.ConverterConfig) []Extend {
 	return []Extend{
 		extender2.ExtendWithAnnotations,
 		extender2.ExtendWithLabels,
-		extender2.ExtendWithSeedInSameRegion,
+		extender2.ExtendWithSeedSelector,
 		extender2.NewDNSExtender(cfg.DNS.SecretName, cfg.DNS.DomainPrefix, cfg.DNS.ProviderType),
 		extender2.NewOidcExtender(cfg.Kubernetes.DefaultOperatorOidc),
 		extender2.ExtendWithCloudProfile,

--- a/pkg/gardener/shoot/converter.go
+++ b/pkg/gardener/shoot/converter.go
@@ -17,6 +17,7 @@ func baseExtenders(cfg config.ConverterConfig) []Extend {
 	return []Extend{
 		extender2.ExtendWithAnnotations,
 		extender2.ExtendWithLabels,
+		extender2.ExtendWithSeedInSameRegion,
 		extender2.NewDNSExtender(cfg.DNS.SecretName, cfg.DNS.DomainPrefix, cfg.DNS.ProviderType),
 		extender2.NewOidcExtender(cfg.Kubernetes.DefaultOperatorOidc),
 		extender2.ExtendWithCloudProfile,

--- a/pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration_test.go
+++ b/pkg/gardener/shoot/extender/auditlogs/auditlogs_configuration_test.go
@@ -72,5 +72,4 @@ func fixTestAuditlogData(id int) AuditLogData {
 		ServiceURL: fmt.Sprintf("https://test.service.%d", id),
 		SecretName: fmt.Sprintf("test-service-%d", id),
 	}
-
 }

--- a/pkg/gardener/shoot/extender/provider_test.go
+++ b/pkg/gardener/shoot/extender/provider_test.go
@@ -202,7 +202,7 @@ func TestProviderExtender(t *testing.T) {
 			CurrentZonesConfig:          []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"},
 			TestForPatch:                true,
 		},
-		//"Patch option different image name - override image name and version with current image name and version": {},
+		// "Patch option different image name - override image name and version with current image name and version": {},
 	} {
 		t.Run(tname, func(t *testing.T) {
 			// given

--- a/pkg/gardener/shoot/extender/seed_in_shoot_region.go
+++ b/pkg/gardener/shoot/extender/seed_in_shoot_region.go
@@ -1,0 +1,15 @@
+package extender
+
+import (
+	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+)
+
+func ExtendWithSeedInSameRegion(runtime imv1.Runtime, shoot *gardener.Shoot) error {
+
+	if runtime.Spec.Shoot.EnforceSeedLocation != nil && *runtime.Spec.Shoot.EnforceSeedLocation {
+		//add required label to the shoot
+	}
+
+	return nil
+}

--- a/pkg/gardener/shoot/extender/seed_in_shoot_region.go
+++ b/pkg/gardener/shoot/extender/seed_in_shoot_region.go
@@ -3,12 +3,21 @@ package extender
 import (
 	gardener "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func ExtendWithSeedInSameRegion(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 
-	if runtime.Spec.Shoot.EnforceSeedLocation != nil && *runtime.Spec.Shoot.EnforceSeedLocation {
+	if runtime.Spec.Shoot.EnforceSeedLocation != nil && *runtime.Spec.Shoot.EnforceSeedLocation && runtime.Spec.Shoot.Region != "" {
 		//add required label to the shoot
+
+		shoot.Spec.SeedSelector = &gardener.SeedSelector{
+			LabelSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"seed.gardener.cloud/region": runtime.Spec.Shoot.Region,
+				},
+			},
+		}
 	}
 
 	return nil

--- a/pkg/gardener/shoot/extender/seed_in_shoot_region.go
+++ b/pkg/gardener/shoot/extender/seed_in_shoot_region.go
@@ -6,19 +6,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	seedRegionSelectorLabel = "seed.gardener.cloud/region"
+)
+
+// ExtendWithSeedInSameRegion creates a new extender function that can enforce shoot seed location to be the same as shoot region
+// When EnforceSeedLocation flag in set on RuntimeCR to true it adds special seedSelector field with labelSelector to match seed region with shoot region
 func ExtendWithSeedInSameRegion(runtime imv1.Runtime, shoot *gardener.Shoot) error {
-
 	if runtime.Spec.Shoot.EnforceSeedLocation != nil && *runtime.Spec.Shoot.EnforceSeedLocation && runtime.Spec.Shoot.Region != "" {
-		//add required label to the shoot
-
 		shoot.Spec.SeedSelector = &gardener.SeedSelector{
 			LabelSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"seed.gardener.cloud/region": runtime.Spec.Shoot.Region,
+					seedRegionSelectorLabel: runtime.Spec.Shoot.Region,
 				},
 			},
 		}
 	}
-
 	return nil
 }

--- a/pkg/gardener/shoot/extender/seed_selector.go
+++ b/pkg/gardener/shoot/extender/seed_selector.go
@@ -10,9 +10,9 @@ const (
 	seedRegionSelectorLabel = "seed.gardener.cloud/region"
 )
 
-// ExtendWithSeedInSameRegion creates a new extender function that can enforce shoot seed location to be the same as shoot region
-// When EnforceSeedLocation flag in set on RuntimeCR to true it adds special seedSelector field with labelSelector to match seed region with shoot region
-func ExtendWithSeedInSameRegion(runtime imv1.Runtime, shoot *gardener.Shoot) error {
+// ExtendWithSeedSelector creates a new extender function that can enforce shoot seed location to be the same region as shoot
+// When EnforceSeedLocation flag in set on RuntimeCR to true it adds a special seedSelector field with labelSelector set to match seed region with shoot region
+func ExtendWithSeedSelector(runtime imv1.Runtime, shoot *gardener.Shoot) error {
 	if runtime.Spec.Shoot.EnforceSeedLocation != nil && *runtime.Spec.Shoot.EnforceSeedLocation && runtime.Spec.Shoot.Region != "" {
 		shoot.Spec.SeedSelector = &gardener.SeedSelector{
 			LabelSelector: metav1.LabelSelector{

--- a/pkg/gardener/shoot/extender/seed_selector_test.go
+++ b/pkg/gardener/shoot/extender/seed_selector_test.go
@@ -1,0 +1,74 @@
+package extender
+
+import (
+	"testing"
+
+	imv1 "github.com/kyma-project/infrastructure-manager/api/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSeedSelectorExtender(t *testing.T) {
+	t.Run("Add and populate seed selector field if RuntimeCR has SeedInSameRegionFlag set to true", func(t *testing.T) {
+		// given
+		runtimeShoot := getRuntimeWithSeedInSameRegionFlag(true)
+		shoot := fixEmptyGardenerShoot("test", "dev")
+
+		// when
+		err := ExtendWithSeedSelector(runtimeShoot, &shoot)
+
+		// then
+		require.NoError(t, err)
+		assert.NotNil(t, shoot.Spec.SeedSelector)
+		assert.Equal(t, runtimeShoot.Spec.Shoot.Region, shoot.Spec.SeedSelector.LabelSelector.MatchLabels[seedRegionSelectorLabel])
+	})
+
+	t.Run("Don't add seed selector field if RuntimeCR has SeedInSameRegionFlag set to false", func(t *testing.T) {
+		// given
+		runtimeShoot := getRuntimeWithSeedInSameRegionFlag(false)
+		shoot := fixEmptyGardenerShoot("test", "dev")
+
+		// when
+		err := ExtendWithSeedSelector(runtimeShoot, &shoot)
+
+		// then
+		require.NoError(t, err)
+		assert.Nil(t, shoot.Spec.SeedSelector)
+	})
+
+	t.Run("Don't add seed selector field if RuntimeCR has no SeedInSameRegionFlag set", func(t *testing.T) {
+		// given
+		runtimeShoot := getRuntimeWithoutSeedInSameRegionFlag()
+		shoot := fixEmptyGardenerShoot("test", "dev")
+
+		// when
+		err := ExtendWithSeedSelector(runtimeShoot, &shoot)
+
+		// then
+		require.NoError(t, err)
+		assert.Nil(t, shoot.Spec.SeedSelector)
+	})
+}
+
+func getRuntimeWithSeedInSameRegionFlag(enabled bool) imv1.Runtime {
+	return imv1.Runtime{
+		Spec: imv1.RuntimeSpec{
+			Shoot: imv1.RuntimeShoot{
+				Name:                "myshoot",
+				EnforceSeedLocation: &enabled,
+				Region:              "far-far-away",
+			},
+		},
+	}
+}
+
+func getRuntimeWithoutSeedInSameRegionFlag() imv1.Runtime {
+	return imv1.Runtime{
+		Spec: imv1.RuntimeSpec{
+			Shoot: imv1.RuntimeShoot{
+				Name:   "myshoot",
+				Region: "far-far-away",
+			},
+		},
+	}
+}


### PR DESCRIPTION
**Implementation**

When EnforceSeedLocation flag is enabled in Runtime CR  
Setting Shoot `seedSelector.matchLabels` field to the value 

`seed.gardener.cloud/region : <Shoot region>`

**Related issue(s)**
https://github.com/kyma-project/infrastructure-manager/issues/241
https://github.com/kyma-project/kyma/issues/18182


**Additional info**
There are some cases for HA dedicated seeds - please make sure this solution will work in case of HA clusters
 
https://github.com/kyma-project/kyma/issues/18182#issuecomment-2133446254