### PR TITLE
configures dependabot for runtime-migrator app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/hack/runtime-migrator" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
**Description**

Dependabot PRs are often failing on the unit test github action with error.

```
Error: load packages in root "/home/runner/work/infrastructure-manager/infrastructure-manager/hack/runtime-migrator": err: exit status 1: stderr: go: updates to go.mod needed; to update it:
	go mod tidy
```

Changes proposed in this pull request:

- adds to dependabot's configuration location of `runtime-migrator` hoping that it will cause it to run `go mod tidy` in the migrator directory.
- ...
- ...

**Related issue(s)**
- #493 
- #494
- #495 
