### PR TITLE
grouping of k8s.io and gardener dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
         - "patch"
       gardener:
         patterns:
-        - "gardener*"
+        - "github.com/gardener/*"
         update-types:
         - "minor"
         - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,18 @@ updates:
     directories: 
       - "/" # Location of package manifests
       - "/hack/runtime-migrator"
+    groups:
+      k8s:
+        patterns:
+        - "k8s.io*"
+        update-types:
+        - "minor"
+        - "patch"
+      gardener:
+        patterns:
+        - "gardener*"
+        update-types:
+        - "minor"
+        - "patch"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
**Description**

Dependabot creates separate PRs for each dependency bump which makes merging them burdersome as each has to be approved after rebase to main.

Changes proposed in this pull request:

- should group `k8s.io` PRs into a single PR
- should group `gardener` PRs into a single PR
- change only affects `minor` and `patch` - `major` bumps will be created as separate PRs

**Related issue(s)**
#500 
