### PR TITLE
bumps kustomize from v4.5.5 to v5.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
-KUSTOMIZE_VERSION ?= v4.5.5
+KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.5
 
 .PHONY: kustomize
@@ -166,7 +166,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
 		rm -rf $(LOCALBIN)/kustomize; \
 	fi
-	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v4@$(KUSTOMIZE_VERSION)
+	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) GO111MODULE=on go install sigs.k8s.io/kustomize/kustomize/v5@$(KUSTOMIZE_VERSION)
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.


### PR DESCRIPTION
**Description**

aims to fix the following issue
```
cd config/manager && /Users/username/infrastructure-manager/bin/kustomize edit set image controller=custom-infrastructure-manager:0.0.1
bash: line 1:  9565 Killed: 9               /Users/username/open-source/infrastructure-manager/bin/kustomize edit set image controller=custom-infrastructure-manager:0.0.1
make: *** [deploy] Error 137
```

Changes proposed in this pull request:

- bumps kustomize from v4.5.5 to v5.5.0
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
