### PR TITLE
Handing missing Disabled field in OIDC extension data to avoid crash

### DIFF
--- a/hack/runtime-migrator/internal/runtime/migrator.go
+++ b/hack/runtime-migrator/internal/runtime/migrator.go
@@ -224,6 +224,9 @@ func getControlPlane(shoot v1beta1.Shoot) *v1beta1.ControlPlane {
 func checkIfShootNetworkFilteringEnabled(shoot v1beta1.Shoot) bool {
 	for _, extension := range shoot.Spec.Extensions {
 		if extension.Type == ShootNetworkingFilterExtensionType {
+			if extension.Disabled == nil {
+				return true
+			}
 			return !(*extension.Disabled)
 		}
 	}

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_oidc.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_oidc.go
@@ -114,6 +114,9 @@ func deleteExistingKymaOpenIDConnectResources(ctx context.Context, client k8s_cl
 func isOidcExtensionEnabled(shoot gardener.Shoot) bool {
 	for _, extension := range shoot.Spec.Extensions {
 		if extension.Type == extender.OidcExtensionType {
+			if extension.Disabled == nil {
+				return true
+			}
 			return !(*extension.Disabled)
 		}
 	}

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_oidc_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_oidc_test.go
@@ -160,6 +160,74 @@ func TestOidcState(t *testing.T) {
 		assertEqualConditions(t, expectedRuntimeConditions, systemState.instance.Status.Conditions)
 	})
 
+	t.Run("Should not crash and configure OIDC using defaults when Disabled field is missing in extension data", func(t *testing.T) {
+		// given
+		ctx := context.Background()
+
+		// start of fake client setup
+		scheme, err := newOIDCTestScheme()
+		require.NoError(t, err)
+		var fakeClient = fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+		testFsm := &fsm{K8s: K8s{
+			ShootClient: fakeClient,
+			Client:      fakeClient,
+		},
+			RCCfg: RCCfg{
+				Config: config.Config{
+					ClusterConfig: config.ClusterConfig{
+						DefaultSharedIASTenant: createConverterOidcConfig("defaut-client-id"),
+					},
+				},
+			},
+		}
+		GetShootClient = func(
+			_ context.Context,
+			_ client.Client,
+			_ imv1.Runtime) (client.Client, error) {
+			return fakeClient, nil
+		}
+		// end of fake client setup
+
+		runtimeStub := runtimeForTest()
+		shootStub := shootForTest()
+		oidcService := gardener.Extension{
+			Type:     "shoot-oidc-service",
+			Disabled: nil,
+		}
+		shootStub.Spec.Extensions = append(shootStub.Spec.Extensions, oidcService)
+
+		systemState := &systemState{
+			instance: runtimeStub,
+			shoot:    shootStub,
+		}
+
+		expectedRuntimeConditions := []metav1.Condition{
+			{
+				Type:    string(imv1.ConditionTypeOidcConfigured),
+				Reason:  string(imv1.ConditionReasonOidcConfigured),
+				Status:  "True",
+				Message: "OIDC configuration completed",
+			},
+		}
+
+		// when
+		stateFn, _, _ := sFnConfigureOidc(ctx, testFsm, systemState)
+
+		// then
+		require.Contains(t, stateFn.name(), "sFnApplyClusterRoleBindings")
+
+		var openIdConnects authenticationv1alpha1.OpenIDConnectList
+
+		err = fakeClient.List(ctx, &openIdConnects)
+		require.NoError(t, err)
+		assert.Len(t, openIdConnects.Items, 1)
+
+		assertOIDCCRD(t, "kyma-oidc-0", "defaut-client-id", openIdConnects.Items[0])
+		assertEqualConditions(t, expectedRuntimeConditions, systemState.instance.Status.Conditions)
+	})
+
 	t.Run("Should configure OIDC based on Runtime CR configuration", func(t *testing.T) {
 		// given
 		ctx := context.Background()


### PR DESCRIPTION
Handling exception case for Patch operation when `Disabled` field is missing from OIDC extension data in the shoot like following: 

```
  extensions:
    - type: shoot-oidc-service
    - type: shoot-dns-service
```

In the old implementation the missing `Disabled` field was causing unexpected crash.

In the new implementation the missing `Disabled` filed is interpreted as **"Enabled by default"** 