### PR TITLE
Configurable number of workers for both controllers with default value 25

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,12 +12,17 @@ Run `make test` to see if all tests are passing.
 
 You can configure the Infrastructure Manager deployment with the following arguments:
 1. `gardener-kubeconfig-path` - defines the path to the Gardener project kubeconfig used during API calls
-2. `gardener-project` - the name of the Gardener project where the infrastructure operations are performed
+2. `gardener-project-name` - the name of the Gardener project where the infrastructure operations are performed
 3. `minimal-rotation-time` - the ratio determines what is the minimal time that needs to pass to rotate the certificate
 4. `kubeconfig-expiration-time` - maximum time after which kubeconfig is rotated. The rotation happens between (`minimal-rotation-time` * `kubeconfig-expiration-time`) and `kubeconfig-expiration-time`.
-4. `gardener-request-timeout` - specifies the timeout for requests to Gardener. Default value is `60s`.
-5. `shoot-spec-dump-enabled` - feature flag responsible for enabling the shoot spec dump. Default value is `false`.
-6. `audit-log-mandatory` - feature flag responsible for enabling the Audit Log strict config. Default value is `true`.
+5. `gardener-request-timeout` - specifies the timeout for requests to Gardener. Default value is `3s`.
+6. `gardener-ctrl-reconcilation-timeout` - timeout for duration of the reconlication for Gardener Cluster Controller. Default value is `60s`.
+7. `gardener-ratelimiter-qps` - Gardener client rate limiter QPS parameter for Runtime Controller.  Default value is `5`.
+8. `gardener-ratelimiter-burst` - Gardener client rate limiter Burst parameter for Runtime Controller.  Default value is `5`.
+9. `shoot-spec-dump-enabled` - feature flag responsible for enabling the shoot spec dump. Default value is `false`.
+10. `audit-log-mandatory` - feature flag responsible for enabling the Audit Log strict config. Default value is `true`.
+11. `runtime-ctrl-workers-cnt` - number of workers running in parallel for Runtime Controller. Default value is `25`.
+12. `gardener-cluster-ctrl-workers-cnt` - number of workers running in parallel for GardenerCluster Controller. Default value is `25`.
 
 
 See [manager_gardener_secret_patch.yaml](../config/default/manager_gardener_secret_patch.yaml) for default values.

--- a/internal/controller/kubeconfig/gardener_cluster_controller.go
+++ b/internal/controller/kubeconfig/gardener_cluster_controller.go
@@ -44,7 +44,6 @@ const (
 	clusterCRNameLabel                = "operator.kyma-project.io/cluster-name"
 
 	rotationPeriodRatio = 0.95
-	numberOfWorkers     = 25
 )
 
 // GardenerClusterController reconciles a GardenerCluster object
@@ -431,7 +430,7 @@ func (controller *GardenerClusterController) newSecret(cluster imv1.GardenerClus
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (controller *GardenerClusterController) SetupWithManager(mgr ctrl.Manager) error {
+func (controller *GardenerClusterController) SetupWithManager(mgr ctrl.Manager, numberOfWorkers int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&imv1.GardenerCluster{}, builder.WithPredicates(predicate.Or(
 			predicate.LabelChangedPredicate{},

--- a/internal/controller/kubeconfig/suite_test.go
+++ b/internal/controller/kubeconfig/suite_test.go
@@ -92,7 +92,7 @@ var _ = BeforeSuite(func() {
 
 	Expect(gardenerClusterController).NotTo(BeNil())
 
-	err = gardenerClusterController.SetupWithManager(mgr)
+	err = gardenerClusterController.SetupWithManager(mgr, 1)
 	Expect(err).To(BeNil())
 
 	Expect(gardenerClusterController).NotTo(BeNil())

--- a/internal/controller/runtime/runtime_controller.go
+++ b/internal/controller/runtime/runtime_controller.go
@@ -31,8 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-const numberOfWorkers = 25
-
 // RuntimeReconciler reconciles a Runtime object
 // nolint:revive
 type RuntimeReconciler struct {
@@ -91,7 +89,7 @@ func NewRuntimeReconciler(mgr ctrl.Manager, shootClient client.Client, logger lo
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *RuntimeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *RuntimeReconciler) SetupWithManager(mgr ctrl.Manager, numberOfWorkers int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&imv1.Runtime{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: numberOfWorkers}).

--- a/internal/controller/runtime/suite_test.go
+++ b/internal/controller/runtime/suite_test.go
@@ -135,7 +135,7 @@ var _ = BeforeSuite(func() {
 
 	runtimeReconciler = NewRuntimeReconciler(mgr, gardenerTestClient, logger, fsmCfg)
 	Expect(runtimeReconciler).NotTo(BeNil())
-	err = runtimeReconciler.SetupWithManager(mgr)
+	err = runtimeReconciler.SetupWithManager(mgr, 1)
 	Expect(err).To(BeNil())
 
 	//+kubebuilder:scaffold:scheme


### PR DESCRIPTION
This PR allows to specify the number of workers for both controllers as program arguments

```
    - --runtime-ctrl-workers-cnt=150
    - --gardener-cluster-ctrl-workers-cnt=33

``` 

If no parameter is provided the with default value for each worker count is 25