### PR TITLE
Add handling of LastOperationStateError shoot operation state while waiting for reconciliation to complete

### DIFF
--- a/internal/controller/runtime/fsm/runtime_fsm_waiting_for_shoot_reconcile.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_waiting_for_shoot_reconcile.go
@@ -14,7 +14,7 @@ func sFnWaitForShootReconcile(_ context.Context, m *fsm, s *systemState) (stateF
 	m.log.Info("Waiting for shoot reconcile state")
 
 	switch s.shoot.Status.LastOperation.State {
-	case gardener.LastOperationStateProcessing, gardener.LastOperationStatePending, gardener.LastOperationStateAborted:
+	case gardener.LastOperationStateProcessing, gardener.LastOperationStatePending, gardener.LastOperationStateAborted, gardener.LastOperationStateError:
 		m.log.Info(fmt.Sprintf("Shoot %s is in %s state, scheduling for retry", s.shoot.Name, s.shoot.Status.LastOperation.State))
 
 		s.instance.UpdateStatePending(

--- a/internal/controller/runtime/suite_test.go
+++ b/internal/controller/runtime/suite_test.go
@@ -276,7 +276,11 @@ func fixShootsSequenceForUpdate(shoot *gardener_api.Shoot) []*gardener_api.Shoot
 
 	pendingShoot.Status.LastOperation.State = gardener_api.LastOperationStatePending
 
-	processingShoot := pendingShoot.DeepCopy()
+	tempErrorShoot := pendingShoot.DeepCopy()
+
+	tempErrorShoot.Status.LastOperation.State = gardener_api.LastOperationStateError
+
+	processingShoot := tempErrorShoot.DeepCopy()
 
 	processingShoot.Status.LastOperation.State = gardener_api.LastOperationStateProcessing
 
@@ -286,7 +290,7 @@ func fixShootsSequenceForUpdate(shoot *gardener_api.Shoot) []*gardener_api.Shoot
 
 	// processedShoot := processingShoot.DeepCopy() // will add specific data later
 
-	return []*gardener_api.Shoot{existingShoot, pendingShoot, processingShoot, readyShoot, readyShoot}
+	return []*gardener_api.Shoot{existingShoot, pendingShoot, tempErrorShoot, processingShoot, readyShoot, readyShoot}
 }
 
 func fixShootsSequenceForDelete(shoot *gardener_api.Shoot) []*gardener_api.Shoot {


### PR DESCRIPTION
Fix of the bug - adding case of checking for `LastOperationStateError` Gardener `shoot.Status.LastOperation.State` in the code executed while waiting for shoot reconciliation. 

LastOperationStateError means it is a retryable error hence you should requeue the reconciliation with a short requeue time.

In preexisting code the `LastOperationStateError` was ignored and reconciliation loop was stopped with message:

`sFnWaitForShootReconcile - unknown shoot operation state, stopping state machine`

After the fix - when the `LastOperationStateError` occurs - the next reconciliation will be scheduled.

**Related issue:**
 Internal-GH/kyma/backlog/issues/6615