### PR TITLE
retry forbidden patch request

### DIFF
--- a/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_patch_shoot.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-project/infrastructure-manager/pkg/reconciler"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
-	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -56,30 +55,23 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 
 	m.log.Info("Shoot converted successfully", "Name", updatedShoot.Name, "Namespace", updatedShoot.Namespace)
 
-	// The additional Update function is required to fully replace shoot Workers collection with workers defined in updated runtime object.
-	// This is a workaround for the sigs.k8s.io/controller-runtime/pkg/client, which does not support replacing the Workers collection with client.Patch
-	// This could caused some workers to be not removed from the shoot object during update
-	// More info: https://github.com/kyma-project/infrastructure-manager/issues/640
+	copyShoot := s.shoot.DeepCopy()
+	copyShoot.Spec.Provider.Workers = updatedShoot.Spec.Provider.Workers
 
-	if !workersAreEqual(s.shoot.Spec.Provider.Workers, updatedShoot.Spec.Provider.Workers) {
-		copyShoot := s.shoot.DeepCopy()
-		copyShoot.Spec.Provider.Workers = updatedShoot.Spec.Provider.Workers
+	err = m.ShootClient.Update(ctx, copyShoot,
+		&client.UpdateOptions{
+			FieldManager: fieldManagerName,
+		})
 
-		err = m.ShootClient.Update(ctx, copyShoot,
-			&client.UpdateOptions{
-				FieldManager: fieldManagerName,
-			})
-
-		if err != nil {
-			if k8serrors.IsConflict(err) {
-				m.log.Info("Gardener shoot for runtime is outdated, retrying", "Name", s.shoot.Name, "Namespace", s.shoot.Namespace)
-				return updateStatusAndRequeueAfter(m.RCCfg.GardenerRequeueDuration)
-			}
-
-			m.log.Error(err, "Failed to update shoot worker list, exiting with no retry")
-			m.Metrics.IncRuntimeFSMStopCounter()
-			return updateStatePendingWithErrorAndStop(&s.instance, imv1.ConditionTypeRuntimeProvisioned, imv1.ConditionReasonProcessingErr, fmt.Sprintf("Gardener API shoot update error: %v", err))
+	if err != nil {
+		if k8serrors.IsConflict(err) {
+			m.log.Info("Gardener shoot for runtime is outdated, retrying", "Name", s.shoot.Name, "Namespace", s.shoot.Namespace)
+			return updateStatusAndRequeueAfter(m.RCCfg.GardenerRequeueDuration)
 		}
+
+		m.log.Error(err, "Failed to update shoot worker list, exiting with no retry")
+		m.Metrics.IncRuntimeFSMStopCounter()
+		return updateStatePendingWithErrorAndStop(&s.instance, imv1.ConditionTypeRuntimeProvisioned, imv1.ConditionReasonProcessingErr, fmt.Sprintf("Gardener API shoot patch error: %v", err))
 	}
 
 	err = m.ShootClient.Patch(ctx, &updatedShoot, client.Apply, &client.PatchOptions{
@@ -89,7 +81,12 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 
 	if err != nil {
 		if k8serrors.IsConflict(err) {
-			m.log.Info("Gardener shoot for runtime is outdated, retrying", "Name", s.shoot.Name, "Namespace", s.shoot.Namespace)
+			m.log.Info("Gardener shoot for runtime is outdated, retrying")
+			return updateStatusAndRequeueAfter(m.RCCfg.GardenerRequeueDuration)
+		}
+
+		if k8serrors.IsForbidden(err) {
+			m.log.Info("Gardener shoot for runtime is forbidden, retrying")
 			return updateStatusAndRequeueAfter(m.RCCfg.GardenerRequeueDuration)
 		}
 
@@ -119,19 +116,6 @@ func sFnPatchExistingShoot(ctx context.Context, m *fsm, s *systemState) (stateFn
 	)
 
 	return updateStatusAndRequeueAfter(m.RCCfg.GardenerRequeueDuration)
-}
-
-func workersAreEqual(workers []gardener.Worker, workers2 []gardener.Worker) bool {
-	if len(workers) != len(workers2) {
-		return false
-	}
-
-	for i := range workers {
-		if !reflect.DeepEqual(workers[i], workers2[i]) {
-			return false
-		}
-	}
-	return true
 }
 
 func handleForceReconciliationAnnotation(runtime *imv1.Runtime, fsm *fsm, ctx context.Context) error {

--- a/internal/controller/runtime/fsm/runtime_fsm_select_shoot_processing.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_select_shoot_processing.go
@@ -46,7 +46,7 @@ func sFnSelectShootProcessing(_ context.Context, m *fsm, s *systemState) (stateF
 			return switchState(sFnWaitForShootCreation)
 		}
 
-		if lastOperation.Type == gardener.LastOperationTypeReconcile {
+ 		if lastOperation.Type == gardener.LastOperationTypeReconcile {
 			return switchState(sFnWaitForShootReconcile)
 		}
 	}


### PR DESCRIPTION
**Description**

Gardener is from time to time unable to correctly respond to our requests, that results in errors similar to this:

`'Gardener API shoot patch error: shoots.core.gardener.cloud "xxx" is forbidden: User "yyy" cannot patch resource "shoots"`

Changes proposed in this pull request:

- Retrying Forbidden patch requests
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
