### PR TITLE
add gh workflow that should assure that all checks are passed before the merge

### DIFF
--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -8,6 +8,7 @@ on:
         reopened,
         ready_for_review,
         edited,
+        unlabeled,
         labeled,
         milestoned,
       ]

--- a/.github/workflows/all-checks-passed.yml
+++ b/.github/workflows/all-checks-passed.yml
@@ -1,0 +1,26 @@
+name: all-checks-passed
+on:
+  pull_request:
+    types:
+      [
+        opened,
+        synchronize,
+        reopened,
+        ready_for_review,
+        edited,
+        labeled,
+        milestoned,
+      ]
+
+jobs:
+  all-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+    steps:
+      - uses: wechuli/allcheckspassed@f4669eca31dbad8fea1a0eb91c419d02c5b42200
+        with:
+          delay: '3'
+          retries: '30'
+          polling_interval: '1'


### PR DESCRIPTION
**Description**
We have to switch from `tide` which was preventing unintended merges of a PR to something else as it is no longer working.

Changes proposed in this pull request:

- adds a gihtub workflow for [allcheckspassed](https://github.com/wechuli/allcheckspassed/tree/main) that assures that all checks passed 
- ...
- ...

**Related issue(s)**
- #666 - was merged even with a test failure
- https://github.com/kyma-project/test-infra/blob/main/.github/workflows/all-checks-passed.yml - this is used in `test-infra` repo
- [research on required checks ](https://github.com/kyma-project/test-infra/issues/12139#issuecomment-2408255908)