### PR TITLE
Extend `RuntimeCR` and KIM logic to mark runtime ready to be billable

### DIFF
--- a/config/crd/bases/infrastructuremanager.kyma-project.io_runtimes.yaml
+++ b/config/crd/bases/infrastructuremanager.kyma-project.io_runtimes.yaml
@@ -1691,6 +1691,9 @@ spec:
           status:
             description: RuntimeStatus defines the observed state of Runtime
             properties:
+              billable:
+                description: Field that represents if cluster can be billed or not
+                type: boolean
               conditions:
                 description: List of status conditions to indicate the status of a
                   ServiceInstance.

--- a/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_apply_clusterrolebindings.go
@@ -58,6 +58,7 @@ func sFnApplyClusterRoleBindings(ctx context.Context, m *fsm, s *systemState) (s
 		"Cluster admin configuration complete",
 	)
 
+	s.instance.UpdateBillableStatus()
 	return updateStatusAndStop()
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- logic added which mark Runtime as Ready to be billable

**Related issue(s)**
#547 