### PR TITLE
Removed check for migrated label in OIDC step

### DIFF
--- a/internal/controller/runtime/fsm/runtime_fsm_configure_oidc.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_oidc.go
@@ -27,18 +27,6 @@ func sFnConfigureOidc(ctx context.Context, m *fsm, s *systemState) (stateFn, *ct
 		return switchState(sFnApplyClusterRoleBindings)
 	}
 
-	if !multiOidcSupported(s.instance) {
-		// New OIDC functionality is supported only for new clusters
-		m.log.Info("Multi OIDC is not supported for migrated runtimes")
-		s.instance.UpdateStatePending(
-			imv1.ConditionTypeOidcConfigured,
-			imv1.ConditionReasonOidcConfigured,
-			"True",
-			"Multi OIDC not supported for migrated runtimes",
-		)
-		return switchState(sFnApplyClusterRoleBindings)
-	}
-
 	defaultAdditionalOidcIfNotPresent(&s.instance, m.RCCfg)
 	err := recreateOpenIDConnectResources(ctx, m, s)
 
@@ -133,10 +121,6 @@ func isOidcExtensionEnabled(shoot gardener.Shoot) bool {
 		}
 	}
 	return false
-}
-
-func multiOidcSupported(runtime imv1.Runtime) bool {
-	return runtime.Labels["operator.kyma-project.io/created-by-migrator"] != "true" //nolint:all
 }
 
 func createOpenIDConnectResource(additionalOidcConfig gardener.OIDCConfig, oidcID int) *authenticationv1alpha1.OpenIDConnect {

--- a/internal/controller/runtime/fsm/runtime_fsm_configure_oidc_test.go
+++ b/internal/controller/runtime/fsm/runtime_fsm_configure_oidc_test.go
@@ -53,45 +53,6 @@ func TestOidcState(t *testing.T) {
 		assertEqualConditions(t, expectedRuntimeConditions, systemState.instance.Status.Conditions)
 	})
 
-	t.Run("Should switch state to ApplyClusterRoleBindings when  multi OIDC support is disabled", func(t *testing.T) {
-		// given
-		ctx := context.Background()
-		fsm := &fsm{}
-
-		runtimeStub := runtimeForTest()
-		runtimeStub.ObjectMeta.Labels = map[string]string{
-			"operator.kyma-project.io/created-by-migrator": "true",
-		}
-
-		shootStub := shootForTest()
-		oidcService := gardener.Extension{
-			Type:     "shoot-oidc-service",
-			Disabled: ptr.To(false),
-		}
-		shootStub.Spec.Extensions = append(shootStub.Spec.Extensions, oidcService)
-
-		systemState := &systemState{
-			instance: runtimeStub,
-			shoot:    shootStub,
-		}
-
-		expectedRuntimeConditions := []metav1.Condition{
-			{
-				Type:    string(imv1.ConditionTypeOidcConfigured),
-				Reason:  string(imv1.ConditionReasonOidcConfigured),
-				Status:  "True",
-				Message: "Multi OIDC not supported for migrated runtimes",
-			},
-		}
-
-		// when
-		stateFn, _, _ := sFnConfigureOidc(ctx, fsm, systemState)
-
-		// then
-		require.Contains(t, stateFn.name(), "sFnApplyClusterRoleBindings")
-		assertEqualConditions(t, expectedRuntimeConditions, systemState.instance.Status.Conditions)
-	})
-
 	t.Run("Should configure OIDC using defaults", func(t *testing.T) {
 		// given
 		ctx := context.Background()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Creating OIDCConnectResources was enabled for new clusters created with KIM only. It was disabled for the clusters created by the Provisioner.

Changes proposed in this pull request:

- Removed check for migrated label in the OIDC Config step

